### PR TITLE
INT-335 use readBigInt64BE and readInt16BE

### DIFF
--- a/src/telemetry/hashes.ts
+++ b/src/telemetry/hashes.ts
@@ -3,14 +3,14 @@ import { randomBytes } from 'node:crypto';
 export const buildSessionId = (): string => {
 	const buffer = randomBytes(8);
 
-	const bigUint = buffer.readBigUint64BE();
+	const bigUint = buffer.readBigInt64BE();
 
 	return String(bigUint);
 };
 
 export const buildExecutionId = (): string => {
 	const buffer = randomBytes(2);
-	const uint = buffer.readUint16BE();
+	const uint = buffer.readInt16BE();
 
 	return String(uint);
 };


### PR DESCRIPTION
Use it because the telemetry backend doesn't support unsigned numbers anymore.