### PR TITLE
Enable telemetry in the VSCode Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@
 - Our experience & research says **more than 40% of developers' time is wasted on code maintenance**. We are here to help you with those tedious undifferentiated tasks.
 
 ---
+## Telemetry
+The extension collects telemetry data since v0.7.0. We use them to improve performance of the extension and to plan new features. We never send PII, OS information, file or folder names.
+
+You can see the schema of the outgoing telemetry messages [here](https://github.com/intuita-inc/intuita-vscode-extension/blob/main/src/telemetry/types.ts).
+
+You can disable telemetry by going into Settings and searching the for `telemetryEnabled` setting under Intuita VSCode Extensions's Settings. We also respect if the `telemetry.telemetryLevel` setting is set to `off`.
+
+---
 ## How Can I Share Feedback? 🎁
 
 - Please share your ideas, questions, feature requests <kbd>[**here**](https://feedback.intuita.io/feature-requests)</kbd>, or chat with us in <kbd>[**Slack**](https://join.slack.com/t/intuita-inc/shared_invite/zt-1bjj5exxi-95yPfWi71HcO2p_sS5L2wA)</kbd>

--- a/package.json
+++ b/package.json
@@ -110,6 +110,12 @@
 					"type": "number",
 					"default": 100,
 					"description": "The maximum number of files to execute any codemod over"
+				},
+				"intuita.telemetryEnabled": {
+					"order": 2,
+					"type": "boolean",
+					"default": "true",
+					"description": "Whether to send any telemetry messages to the Intuita servers."
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "intuita-vscode-extension",
 	"displayName": "Intuita",
 	"description": "Automatic Code Modification, Built For Scale",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"publisher": "Intuita",
 	"icon": "img/intuita_square128.png",
 	"repository": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,9 +8,18 @@ export const getConfiguration = () => {
 
 	const fileLimit = configuration.get<number>('fileLimit') ?? 100;
 
+	const telemetryConfiguration = vscode.workspace.getConfiguration('telemetry');
+
+	const telemetryLevel = telemetryConfiguration.get<string>('telemetryLevel') ?? 'all'
+
+	const telemetryEnabled = telemetryLevel !== 'off'
+		? (configuration.get<boolean>('telemetryEnabled') ?? true)
+		: false;
+
 	return {
 		saveDocumentOnJobAccept,
 		fileLimit,
+		telemetryEnabled,
 	};
 };
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -8,13 +8,16 @@ export const getConfiguration = () => {
 
 	const fileLimit = configuration.get<number>('fileLimit') ?? 100;
 
-	const telemetryConfiguration = vscode.workspace.getConfiguration('telemetry');
+	const telemetryConfiguration =
+		vscode.workspace.getConfiguration('telemetry');
 
-	const telemetryLevel = telemetryConfiguration.get<string>('telemetryLevel') ?? 'all'
+	const telemetryLevel =
+		telemetryConfiguration.get<string>('telemetryLevel') ?? 'all';
 
-	const telemetryEnabled = telemetryLevel !== 'off'
-		? (configuration.get<boolean>('telemetryEnabled') ?? true)
-		: false;
+	const telemetryEnabled =
+		telemetryLevel !== 'off'
+			? configuration.get<boolean>('telemetryEnabled') ?? true
+			: false;
 
 	return {
 		saveDocumentOnJobAccept,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -554,7 +554,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	new InformationMessageService(messageBus, () => context.storageUri ?? null);
 
-	new TelemetryService(messageBus);
+	new TelemetryService(configurationContainer, messageBus);
 
 	messageBus.publish({
 		kind: MessageKind.bootstrapEngines,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import {
 import { buildTypeCodec } from './utilities';
 import prettyReporter from 'io-ts-reporters';
 import { buildExecutionId } from './telemetry/hashes';
+import { TelemetryService } from './telemetry/telemetryService';
 
 const messageBus = new MessageBus();
 
@@ -552,6 +553,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	dependencyService.showInformationMessagesAboutUpgrades();
 
 	new InformationMessageService(messageBus, () => context.storageUri ?? null);
+
+	new TelemetryService(messageBus);
 
 	messageBus.publish({
 		kind: MessageKind.bootstrapEngines,

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -147,6 +147,6 @@ export class TelemetryService {
 	}
 
 	#buildUrl(): string {
-		return 'http://localhost:4001/messages';
+		return 'https://telemetry.intuita.io/messages';
 	}
 }

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -147,6 +147,6 @@ export class TelemetryService {
 	}
 
 	#buildUrl(): string {
-		throw new Error('Not implemented');
+		return 'http://localhost:4001/messages';
 	}
 }

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -146,7 +146,10 @@ export class TelemetryService {
 		}
 
 		try {
-			await Axios.post(url, telemetryMessage, { maxRedirects: 0, timeout: 5000 });
+			await Axios.post(url, telemetryMessage, {
+				maxRedirects: 0,
+				timeout: 5000,
+			});
 		} catch (error) {
 			if (!Axios.isAxiosError(error)) {
 				console.error(error);


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-338/enable-telemetry-in-the-vscode-extension

Changes:
* check if the user wants telemetry to be sent + add the telemetry settings into the extension config
* add a README info on telemetry
* timeout telemetry requests to 5000ms