### PR TITLE
INT-350 allow spaces in executable paths

### DIFF
--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -215,8 +215,9 @@ export class EngineService {
 				? CaseKind.REWRITE_FILE_BY_NORA_NODE_ENGINE
 				: CaseKind.REWRITE_FILE_BY_NORA_RUST_ENGINE;
 
-		const childProcess = spawn(executableUri.fsPath, args, {
+		const childProcess = spawn(`"${executableUri.fsPath}"`, args, {
 			stdio: 'pipe',
+			shell: true,
 		});
 
 		childProcess.stderr.on('data', (data) => {

--- a/src/components/noraCompareServiceEngine.ts
+++ b/src/components/noraCompareServiceEngine.ts
@@ -19,8 +19,9 @@ class CompareProcessWrapper {
 		executionId: string,
 		messageBus: MessageBus,
 	) {
-		this.#process = spawn(executableUri.fsPath, [], {
+		this.#process = spawn(`"${executableUri.fsPath}"`, [], {
 			stdio: 'pipe',
+			shell: true,
 		});
 
 		this.#process.on('error', (error) => {


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-350/fix-spawn-working-with-spaces

Changes:
* use quotes in executable paths and pass shell:true to spawn