### PR TITLE
Execute recipe over a directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
 			{
 				"command": "intuita.executeAsCodemod",
 				"title": "Intuita: Run as a codemod"
+			},
+			{
+				"command": "intuita.executeRecipeWithinPath",
+				"title": "Intuita: Execute Recipe Within Path"
 			}
 		],
 		"configuration": {
@@ -208,6 +212,11 @@
 					"command": "intuita.executeAsCodemod",
 					"group": "2_workspace",
 					"when": "resourceExtname == .js || resourceExtname == .ts"
+				},
+				{
+					"command": "intuita.executeRecipeWithinPath",
+					"group": "2_workspace",
+					"when": "explorerResourceIsFolder"
 				}
 			],
 			"view/title": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "intuita-vscode-extension",
 	"displayName": "Intuita",
 	"description": "Upgrade dependencies faster with high-quality codemods.",
-	"version": "0.8.5",
+	"version": "0.9.0",
 	"publisher": "Intuita",
 	"icon": "img/intuita_square128.png",
 	"repository": {

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -218,8 +218,8 @@ export class EngineService {
 				args.push('-f', singleQuotify(message.command.fileUri.fsPath));
 			}
 
-			if ('group' in message.command) {
-				args.push('-g', message.command.group);
+			if ('recipeName' in message.command) {
+				args.push('-g', message.command.recipeName);
 			}
 
 			args.push('-o', singleQuotify(outputUri.fsPath));
@@ -246,7 +246,7 @@ export class EngineService {
 		const executionId = message.executionId;
 
 		const codemodSetName =
-			'group' in message.command ? message.command.group : '';
+			'recipeName' in message.command ? message.command.recipeName : '';
 
 		this.#execution = {
 			childProcess,

--- a/src/components/informationMessageService.ts
+++ b/src/components/informationMessageService.ts
@@ -61,7 +61,7 @@ export class InformationMessageService {
 				engine: 'node',
 				storageUri,
 				uri,
-				group,
+				recipeName: group,
 			},
 			executionId,
 			happenedAt,

--- a/src/components/informationMessageService.ts
+++ b/src/components/informationMessageService.ts
@@ -46,9 +46,9 @@ export class InformationMessageService {
 			return;
 		}
 
-		const group = dependencyNameToRecipeName[message.dependencyName];
+		const recipeName = dependencyNameToRecipeName[message.dependencyName];
 
-		if (!group) {
+		if (!recipeName) {
 			return;
 		}
 
@@ -61,7 +61,7 @@ export class InformationMessageService {
 				engine: 'node',
 				storageUri,
 				uri,
-				recipeName: group,
+				recipeName,
 			},
 			executionId,
 			happenedAt,

--- a/src/components/informationMessageService.ts
+++ b/src/components/informationMessageService.ts
@@ -1,8 +1,9 @@
 import { Uri, window } from 'vscode';
+import { RecipeName } from '../recipes/codecs';
 import { buildExecutionId } from '../telemetry/hashes';
-import { Group, Message, MessageBus, MessageKind } from './messageBus';
+import { Message, MessageBus, MessageKind } from './messageBus';
 
-export const dependencyNameToGroup: Record<string, Group> = {
+export const dependencyNameToRecipeName: Record<string, RecipeName> = {
 	next: 'nextJs',
 	'@material-ui/core': 'mui',
 	'@redwoodjs/core': 'redwoodjs_core_4',
@@ -45,7 +46,7 @@ export class InformationMessageService {
 			return;
 		}
 
-		const group = dependencyNameToGroup[message.dependencyName];
+		const group = dependencyNameToRecipeName[message.dependencyName];
 
 		if (!group) {
 			return;

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -53,7 +53,7 @@ export type Engine = 'node' | 'rust';
 
 export type Command =
 	| Readonly<{
-			group: RecipeName;
+			recipeName: RecipeName;
 			engine: Engine;
 			storageUri: Uri;
 			uri: Uri;

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -1,6 +1,7 @@
 import { Disposable, EventEmitter, Uri } from 'vscode';
 import type { CaseHash, CaseKind, CaseWithJobHashes } from '../cases/types';
 import type { Job, JobHash } from '../jobs/types';
+import { RecipeName } from '../recipes/codecs';
 
 export const enum MessageKind {
 	/** the elements are tree entries */
@@ -50,19 +51,9 @@ export const enum MessageKind {
 
 export type Engine = 'node' | 'rust';
 
-export type Group =
-	| 'nextJs'
-	| 'next_13_composite'
-	| 'mui'
-	| 'reactrouterv4'
-	| 'reactrouterv6'
-	| 'immutablejsv4'
-	| 'immutablejsv0'
-	| 'redwoodjs_core_4';
-
 export type Command =
 	| Readonly<{
-			group: Group;
+			group: RecipeName;
 			engine: Engine;
 			storageUri: Uri;
 			uri: Uri;

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -49,6 +49,7 @@ export const enum MessageKind {
 }
 
 export type Engine = 'node' | 'rust';
+
 export type Group =
 	| 'nextJs'
 	| 'next_13_composite'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import {
 } from './persistedState/mappers';
 // import { DependencyService } from './dependencies/dependencyService';
 import {
-	dependencyNameToGroup,
+	dependencyNameToRecipeName,
 	InformationMessageService,
 } from './components/informationMessageService';
 import { buildTypeCodec } from './utilities';
@@ -244,9 +244,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
 			const uri = vscode.Uri.file(path);
 
-			const group = dependencyNameToGroup[dependencyName];
+			const recipeName = dependencyNameToRecipeName[dependencyName];
 
-			if (!group) {
+			if (!recipeName) {
 				return;
 			}
 
@@ -259,7 +259,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					engine: 'node',
 					storageUri,
 					uri,
-					group,
+					group: recipeName,
 				},
 				executionId,
 				happenedAt,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,7 +259,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					engine: 'node',
 					storageUri,
 					uri,
-					group: recipeName,
+					recipeName: recipeName,
 				},
 				executionId,
 				happenedAt,
@@ -295,7 +295,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'nextJs',
+						recipeName: 'nextJs',
 						uri,
 					},
 					executionId,
@@ -333,7 +333,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'next_13_composite',
+						recipeName: 'next_13_composite',
 						uri,
 					},
 					executionId,
@@ -371,7 +371,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'rust',
 						storageUri,
-						group: 'nextJs',
+						recipeName: 'nextJs',
 						uri,
 					},
 					executionId,
@@ -409,7 +409,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'mui',
+						recipeName: 'mui',
 						uri,
 					},
 					executionId,
@@ -447,7 +447,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'reactrouterv4',
+						recipeName: 'reactrouterv4',
 						uri,
 					},
 					executionId,
@@ -485,7 +485,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'reactrouterv6',
+						recipeName: 'reactrouterv6',
 						uri,
 					},
 					executionId,
@@ -522,7 +522,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				command: {
 					engine: 'node',
 					storageUri,
-					group: 'immutablejsv0',
+					recipeName: 'immutablejsv0',
 					uri,
 				},
 				executionId,
@@ -559,7 +559,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'immutablejsv4',
+						recipeName: 'immutablejsv4',
 						uri,
 					},
 					executionId,
@@ -597,7 +597,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group: 'redwoodjs_core_4',
+						recipeName: 'redwoodjs_core_4',
 						uri,
 					},
 					executionId,
@@ -759,7 +759,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					throw new Error('No storage URI, aborting the command.');
 				}
 
-				const group = await vscode.window.showQuickPick(
+				const recipeName = await vscode.window.showQuickPick(
 					RECIPE_NAMES.slice(),
 					{
 						placeHolder:
@@ -767,7 +767,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					},
 				);
 
-				if (!recipeNameCodec.is(group)) {
+				if (!recipeNameCodec.is(recipeName)) {
 					return;
 				}
 
@@ -779,7 +779,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					command: {
 						engine: 'node',
 						storageUri,
-						group,
+						recipeName,
 						uri,
 					},
 					executionId,

--- a/src/recipes/codecs.ts
+++ b/src/recipes/codecs.ts
@@ -1,0 +1,16 @@
+import * as t from 'io-ts';
+
+export const recipeNameCodec = t.union([
+	t.literal('nextJs'),
+	t.literal('next_13_composite'),
+	t.literal('mui'),
+	t.literal('reactrouterv4'),
+	t.literal('reactrouterv6'),
+	t.literal('immutablejsv4'),
+	t.literal('immutablejsv0'),
+	t.literal('redwoodjs_core_4'),
+]);
+
+export type RecipeName = t.TypeOf<typeof recipeNameCodec>;
+
+export const RECIPE_NAMES = recipeNameCodec.types.map((type) => type.value);

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -72,7 +72,9 @@ export class TelemetryService {
 			happenedAt: String(Date.now()),
 			executionId: message.executionId,
 			codemodSetName:
-				'group' in message.command ? message.command.group : '',
+				'recipeName' in message.command
+					? message.command.recipeName
+					: '',
 		});
 	}
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,7 @@
 import * as t from 'io-ts';
 import { createHash } from 'crypto';
+import { Uri } from 'vscode';
+import { basename } from 'path';
 
 export type IntuitaRange = Readonly<[number, number, number, number]>;
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,5 @@
 import * as t from 'io-ts';
 import { createHash } from 'crypto';
-import { Uri } from 'vscode';
-import { basename } from 'path';
 
 export type IntuitaRange = Readonly<[number, number, number, number]>;
 


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-374/[deployment]-ability-to-run-a-set-against-a-target-folder

Right click on a directory in the explorer view and select "execute recipe within a path"
![Screenshot 2023-02-08 13:50:21](https://user-images.githubusercontent.com/35925521/217534482-f4aab471-ae42-4ef4-baea-62d439b30e55.png)

Now, select a codemod set (recipe) to execute:

![Screenshot 2023-02-08 13:56:01](https://user-images.githubusercontent.com/35925521/217535824-468266ad-7f63-47f6-a3cb-3d3bd0bea088.png)

The codemod set will then execute over the provided directory (path).
