### PR TITLE
[IDE ext.] Display Warning Message if no imported mod exists and user tries to execute "imported mod on path" + do not execute

### DIFF
--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -14,6 +14,7 @@ import { StatusBarItemManager } from './statusBarItemManager';
 
 export const Messages = {
 	noAffectedFiles: 'The codemod has run successfully but didn’t do anything',
+	noImportedMod: 'No imported codemod was found',
 	errorRunningCodemod: 'An error occurred while running the codemod',
 	codemodUnrecognized: 'The codemod is invalid / unsupported',
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { CaseHash } from './cases/types';
 import { DownloadService } from './components/downloadService';
 import { FileSystemUtilities } from './components/fileSystemUtilities';
 import { NoraCompareServiceEngine } from './components/noraCompareServiceEngine';
-import { EngineService } from './components/engineService';
+import { EngineService, Messages } from './components/engineService';
 import { BootstrapExecutablesService } from './components/bootstrapExecutablesService';
 import { StatusBarItemManager } from './components/statusBarItemManager';
 import { PersistedStateService } from './persistedState/persistedStateService';
@@ -33,7 +33,6 @@ import {
 	projectNameCodec,
 	PROJECT_NAMES,
 	RECIPE_MAP,
-	RecipeName,
 	recipeNameCodec,
 } from './recipes/codecs';
 import { IntuitaTextDocumentContentProvider } from './components/textDocumentContentProvider';
@@ -1265,9 +1264,15 @@ export async function activate(context: vscode.ExtensionContext) {
 				);
 
 				const text = document.getText();
+
+				// `jscodeshiftCodemod.ts` is empty or the file doesn't exist
+				if (!text) {
+					vscode.window.showWarningMessage(Messages.noImportedMod);
+					return;
+				}
+
 				const buffer = Buffer.from(text);
 				const content = new Uint8Array(buffer);
-
 				vscode.workspace.fs.writeFile(modUri, content);
 
 				const happenedAt = String(Date.now());


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-748/[ide-ext]-display-warning-message-if-no-imported-mod-exists-and-user

### Before

![Screenshot 2023-04-06 at 13 44 56](https://user-images.githubusercontent.com/32841130/230389536-a8224d4e-ea21-4499-a8f5-ca04cc07e493.png)

### After

![Screenshot 2023-04-06 at 14 11 18](https://user-images.githubusercontent.com/32841130/230389539-1d8dd5dc-7ece-4c12-9dc7-d35a71e432b4.png)
