### PR TITLE
Display new uri in folder breakdown view based on JobKind

### DIFF
--- a/src/components/webview/MainWebviewProvider.ts
+++ b/src/components/webview/MainWebviewProvider.ts
@@ -304,11 +304,24 @@ export class IntuitaProvider implements WebviewViewProvider {
 			const uriSet = new Set<Uri>();
 
 			for (const job of jobs) {
-				if (job.kind === JobKind.createFile && job.newUri) {
+				if (
+					[
+						JobKind.createFile,
+						JobKind.moveFile,
+						JobKind.moveAndRewriteFile,
+						JobKind.copyFile,
+					].includes(job.kind) &&
+					job.newUri
+				) {
 					uriSet.add(job.newUri);
 				}
 
-				if (job.kind !== JobKind.createFile && job.oldUri) {
+				if (
+					[JobKind.rewriteFile, JobKind.deleteFile].includes(
+						job.kind,
+					) &&
+					job.oldUri
+				) {
 					uriSet.add(job.oldUri);
 				}
 			}


### PR DESCRIPTION
I think it makes more sense to display the new uri in folder hierarchy view for `create / move / move & rewrite / copy` and the old uri for `rewrite / delete`. I modify the labels attached to file element, because that is what we use to create folder hierarchy map.