### PR TITLE
Explore by folder in Codemod-first breakdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,12 +405,12 @@
 			"view/title": [
 				{
 					"command": "intuita.caseBreakdown",
-					"when": "view == intuitaMainWebviewExplorer || view == intuitaMainWebview",
+					"when": "false",
 					"group": "navigation"
 				},
 				{
 					"command": "intuita.folderBreakdown",
-					"when": "view == intuitaMainWebviewExplorer || view == intuitaMainWebview",
+					"when": "false",
 					"group": "navigation"
 				},
 				{

--- a/src/components/webview/MainWebviewProvider.ts
+++ b/src/components/webview/MainWebviewProvider.ts
@@ -674,13 +674,13 @@ export class IntuitaProvider implements WebviewViewProvider {
 	private __buildCaseTree = (element: CaseElement): TreeNode => {
 		const actions = [
 			{
-				title: '✗ Discard',
-				command: 'intuita.rejectCase',
+				title: '✓ Commit',
+				command: 'intuita.acceptCase',
 				arguments: [element.hash],
 			},
 			{
-				title: '✓ Commit',
-				command: 'intuita.acceptCase',
+				title: '✗ Discard',
+				command: 'intuita.rejectCase',
 				arguments: [element.hash],
 			},
 		];

--- a/src/components/webview/MainWebviewProvider.ts
+++ b/src/components/webview/MainWebviewProvider.ts
@@ -147,6 +147,8 @@ export class IntuitaProvider implements WebviewViewProvider {
 
 		if (element.kind === ElementKind.CASE) {
 			if (this.__codemodMap.has(element.codemodName)) {
+				// This conditional never should be true.
+				// If it is true, it means there are `CASE` elements with the same codemod name.
 				return;
 			}
 			this.__codemodMap.set(

--- a/src/components/webview/MainWebviewProvider.ts
+++ b/src/components/webview/MainWebviewProvider.ts
@@ -25,6 +25,7 @@ import {
 } from '../../elements/types';
 import { Job, JobHash, JobKind } from '../../jobs/types';
 import {
+	buildHash,
 	buildTreeRootLabel,
 	debounce,
 	getElementIconBaseName,
@@ -202,8 +203,8 @@ export class IntuitaProvider implements WebviewViewProvider {
 								command: 'intuita.acceptFolder',
 								arguments: [
 									{
-										id: path,
-										caseHash: element.caseHash,
+										path,
+										hash: buildHash(path),
 										jobHashes: jobHashesArg,
 									},
 								],

--- a/src/elements/buildCaseElement.ts
+++ b/src/elements/buildCaseElement.ts
@@ -14,6 +14,7 @@ export const buildCaseElement = (
 		label: `${kase.subKind} (${count})`,
 		children,
 		hash: kase.hash as unknown as ElementHash,
+		codemodName: kase.codemodName,
 	};
 };
 

--- a/src/elements/buildFileElement.ts
+++ b/src/elements/buildFileElement.ts
@@ -14,6 +14,7 @@ export const buildFileElement = (
 		label: `${label} (${count})`,
 		children,
 		hash: buildHash(`${caseHash}${label}`) as ElementHash,
+		caseHash,
 	};
 };
 

--- a/src/elements/types.ts
+++ b/src/elements/types.ts
@@ -24,6 +24,7 @@ export type FileElement = Readonly<{
 	kind: ElementKind.FILE;
 	label: string;
 	children: ReadonlyArray<JobElement>;
+	caseHash: string;
 }>;
 
 export type CaseElement = Readonly<{

--- a/src/elements/types.ts
+++ b/src/elements/types.ts
@@ -31,6 +31,7 @@ export type CaseElement = Readonly<{
 	kind: ElementKind.CASE;
 	label: string;
 	children: ReadonlyArray<FileElement>;
+	codemodName: string;
 }>;
 
 export type RootElement = Readonly<{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1312,8 +1312,8 @@ export async function activate(context: vscode.ExtensionContext) {
 			async (arg0) => {
 				try {
 					const codec = buildTypeCodec({
-						id: t.string,
-						caseHash: t.string,
+						path: t.string,
+						hash: t.string,
 						jobHashes: t.readonlyArray(t.string),
 					});
 
@@ -1328,8 +1328,8 @@ export async function activate(context: vscode.ExtensionContext) {
 					}
 
 					const {
-						id,
-						caseHash,
+						path,
+						hash,
 						jobHashes: _jobHashes,
 					} = validation.right;
 
@@ -1370,8 +1370,8 @@ export async function activate(context: vscode.ExtensionContext) {
 						});
 					}
 
-					const targetBranchName = `${id}-${caseHash.toLowerCase()}`;
-					const title = id;
+					const targetBranchName = `${path}-${hash.toLowerCase()}`;
+					const title = path;
 					const body = buildStackedBranchPRMessage(
 						repositoryService.getStackedBranches(),
 					);


### PR DESCRIPTION
### Linear: https://linear.app/intuita/issue/INT-843/explore-by-folder-in-codemod-first-breakdown

> - Allow user to explore by folder in Codemod-first breakdown
> - Consequently, we no longer display the list of individual jobs under each case

> New design is:
> - For each case, there is a root folder with subfolders. 
> - Each folder has "Commit" / "Discard" button.

### Result
https://user-images.githubusercontent.com/32841130/233623062-7e7bb585-e5ce-4a45-b050-d02b6b9b8d96.mov