### PR TITLE
INT-862 save jobs in the execution object

### DIFF
--- a/src/components/jobManager.ts
+++ b/src/components/jobManager.ts
@@ -144,8 +144,6 @@ export class JobManager {
 	}
 
 	public async acceptJobs(jobHashes: ReadonlySet<JobHash>): Promise<void> {
-		// HERE
-
 		const { codemodHashJobHashSetManager, codemods } =
 			this.#buildCodemodObjects(jobHashes);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		messageBus,
 		vscode.workspace.fs,
 		statusBarItemManager,
+		fileService,
 	);
 
 	new BootstrapExecutablesService(


### PR DESCRIPTION
Changes:
* add `mode` to the execution object
* add `jobs` to the execution object
* `acceptJobs` when the execution's mode was dirty-run