### PR TITLE
Scroll into header of diff view rather than its body on selecting file in "Change Explorer"

### DIFF
--- a/intuita-webview/src/jobDiffView/App.tsx
+++ b/intuita-webview/src/jobDiffView/App.tsx
@@ -82,7 +82,7 @@ function App() {
 			}
 
 			if (message.kind === 'webview.diffView.focusFile') {
-				const elementId = `diffViewContainer-${message.jobHash}`;
+				const elementId = `diffViewHeader-${message.jobHash}`;
 				const element = document.getElementById(elementId);
 				element?.scrollIntoView();
 			}

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -7,7 +7,6 @@ import { JobKind } from '../../shared/constants';
 import { Diff } from './Diff';
 
 type ContainerProps = Readonly<{
-	id: string;
 	oldFileName: string | null;
 	newFileName: string | null;
 	viewType: 'inline' | 'side-by-side';
@@ -15,13 +14,9 @@ type ContainerProps = Readonly<{
 }>;
 
 export const Container = forwardRef<HTMLDivElement, ContainerProps>(
-	(
-		{ id, oldFileName, newFileName, children, viewType }: ContainerProps,
-		ref,
-	) => {
+	({ oldFileName, newFileName, children, viewType }: ContainerProps, ref) => {
 		return (
 			<div
-				id={id}
 				className="flex  flex-wrap w-full container flex-col"
 				ref={ref}
 			>
@@ -43,6 +38,7 @@ export const Container = forwardRef<HTMLDivElement, ContainerProps>(
 );
 
 type HeaderProps = Readonly<{
+	id: string;
 	diff: Diff | null;
 	title: string;
 	newFileTitle: string;
@@ -61,11 +57,10 @@ type HeaderProps = Readonly<{
 }>;
 
 export const Header = ({
+	id,
 	diff,
 	title,
 	jobKind,
-	newFileTitle,
-	oldFileTitle,
 	children,
 	viewed,
 	actions,
@@ -77,7 +72,7 @@ export const Header = ({
 }: HeaderProps) => {
 	const shouldShowDiff = diff && showDiff(jobKind as unknown as JobKind);
 	return (
-		<div className="flex w-full items-center container-header">
+		<div id={id} className="flex w-full items-center container-header">
 			<div className="flex flex-row flex-1 justify-between flex-wrap">
 				<VSCodeCheckbox checked={jobStaged} onChange={onToggleJob} />
 				<div className="flex items-center flex-1">

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -91,13 +91,7 @@ export const Header = ({
 						lockScroll
 						on={['hover', 'focus']}
 					>
-						<div>
-							{getJobTitle(
-								jobKind as unknown as JobKind,
-								newFileTitle,
-								oldFileTitle,
-							)}
-						</div>
+						<div>{title}</div>
 					</Popup>
 				</div>
 
@@ -161,28 +155,5 @@ const showDiff = (jobKind: JobKind): boolean => {
 			return false;
 		default:
 			return true;
-	}
-};
-
-const getJobTitle = (
-	jobKind: JobKind,
-	oldFileTitle: string,
-	newFileContent: string,
-): string => {
-	switch (jobKind) {
-		case JobKind.copyFile:
-			return `Copy ${oldFileTitle} to ${newFileContent}`;
-		case JobKind.createFile:
-			return `Create new File ${newFileContent}`;
-		case JobKind.deleteFile:
-			return `Delete File`;
-		case JobKind.moveAndRewriteFile:
-			return `Move and Rewrite ${oldFileTitle} to ${newFileContent}`;
-		case JobKind.moveFile:
-			return `Move ${oldFileTitle} to ${newFileContent}`;
-		case JobKind.rewriteFile:
-			return `Modified Contet of ${oldFileTitle} `;
-		default:
-			throw new Error('Unknown job kind');
 	}
 };

--- a/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
@@ -85,6 +85,7 @@ export const JobDiffView = ({
 			headerSticky
 			headerComponent={
 				<Header
+					id={`diffViewHeader-${jobHash}`}
 					diff={diff}
 					oldFileTitle={oldFileTitle ?? ''}
 					newFileTitle={newFileTitle ?? ''}
@@ -103,7 +104,6 @@ export const JobDiffView = ({
 			}
 		>
 			<Container
-				id={`diffViewContainer-${jobHash}`}
 				viewType={viewType}
 				oldFileName={oldFileTitle}
 				newFileName={newFileTitle}

--- a/src/components/webview/DiffWebviewPanel.ts
+++ b/src/components/webview/DiffWebviewPanel.ts
@@ -138,7 +138,6 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 
 		const job = this.__jobManager.getJob(jobHash);
 		// @TODO
-		const jobAccepted = this.__jobManager.isJobApplied(jobHash);
 
 		if (!job) {
 			return null;
@@ -158,40 +157,6 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 		const oldFileContent = oldContentUri
 			? (await workspace.fs.readFile(oldContentUri)).toString()
 			: null;
-		const getTitle = function () {
-			switch (kind) {
-				case JobKind.createFile:
-					return `${
-						jobAccepted ? 'Created' : 'Create'
-					} ${newFileTitle}`;
-				case JobKind.deleteFile:
-					return `${
-						jobAccepted ? 'Deleted' : 'Delete'
-					} ${oldFileTitle}`;
-
-				case JobKind.moveFile:
-					return `${
-						jobAccepted ? 'Moved' : 'Move'
-					} ${oldFileTitle} -> ${newFileTitle}`;
-
-				case JobKind.moveAndRewriteFile:
-					return `${
-						jobAccepted ? 'Moved and rewritten' : 'Move and rewrite'
-					} ${oldFileTitle} -> ${newFileTitle}`;
-				case JobKind.copyFile:
-					return `${
-						jobAccepted ? 'Copied' : 'Copy'
-					} ${oldFileTitle} -> ${newFileTitle}`;
-
-				case JobKind.rewriteFile:
-					return `${
-						jobAccepted ? 'Rewritten' : 'Rewrite'
-					} ${newFileTitle}`;
-
-				default:
-					throw new Error('unknown jobkind');
-			}
-		};
 
 		return {
 			jobHash,
@@ -215,7 +180,7 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 				? { oldFileContent }
 				: { oldFileContent: null }),
 			newFileContent,
-			title: getTitle(),
+			title: newFileTitle,
 			actions: [],
 		};
 	}


### PR DESCRIPTION
As a result, we scroll into the top of the diff view more precisely than before.