### PR TITLE
fix job staging, fix apply 'copy' codemod

### DIFF
--- a/intuita-webview/src/jobDiffView/App.tsx
+++ b/intuita-webview/src/jobDiffView/App.tsx
@@ -15,14 +15,13 @@ const getViewComponent = (
 ) => {
 	switch (view.viewId) {
 		case 'jobDiffView':
-			const { data, title, diffId, changesAccepted } = view.viewProps;
+			const { data, title, diffId } = view.viewProps;
 
 			return (
 				<JobDiffViewContainer
 					diffId={diffId}
 					title={title}
 					jobs={data}
-					changesAccepted={changesAccepted}
 					postMessage={postMessage}
 				/>
 			);
@@ -63,41 +62,11 @@ function App() {
 					},
 				});
 			}
-			if (
-				message.kind === 'webview.diffview.rejectedJob' &&
-				view.viewId === 'jobDiffView'
-			) {
-				const jobHash = message.data[0];
-				const nextData = view.viewProps.data.filter(
-					(element) => element.jobHash !== jobHash,
-				);
-
-				setView({
-					...view,
-					viewProps: {
-						...view.viewProps,
-						data: nextData,
-					},
-				});
-			}
 
 			if (message.kind === 'webview.diffView.focusFile') {
 				const elementId = `diffViewHeader-${message.jobHash}`;
 				const element = document.getElementById(elementId);
 				element?.scrollIntoView();
-			}
-
-			if (
-				message.kind === 'webview.diffView.setChangesAccepted' &&
-				view.viewId === 'jobDiffView'
-			) {
-				setView({
-					...view,
-					viewProps: {
-						...view.viewProps,
-						changesAccepted: message.value,
-					},
-				});
 			}
 		},
 		[view],

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -5,7 +5,6 @@ import './Container.css';
 import { JobAction, JobDiffViewProps } from '../../shared/types';
 import { JobKind } from '../../shared/constants';
 import { Diff } from './Diff';
-import cn from 'classnames';
 
 type ContainerProps = Readonly<{
 	oldFileName: string | null;
@@ -50,12 +49,11 @@ type HeaderProps = Readonly<{
 	children?: React.ReactNode;
 	actions: JobDiffViewProps['actions'];
 	jobStaged: boolean;
-	changesAccepted: boolean;
 	onAction: (arg: JobAction) => void;
 	onViewedChange: () => void;
 	onViewTypeChange: (viewType: 'inline' | 'side-by-side') => void;
 	onReportIssue(): void;
-	onToggleJob(): void;
+	onToggleJob(staged: boolean): void;
 }>;
 
 export const Header = ({
@@ -67,7 +65,6 @@ export const Header = ({
 	viewed,
 	actions,
 	jobStaged,
-	changesAccepted,
 	onToggleJob,
 	onViewedChange,
 	onAction,
@@ -79,8 +76,10 @@ export const Header = ({
 			<div className="flex flex-row flex-1 justify-between flex-wrap">
 				<VSCodeCheckbox
 					checked={jobStaged}
-					disabled={changesAccepted}
-					onChange={onToggleJob}
+					onClick={(e) => {
+						e.stopPropagation();
+						onToggleJob(!jobStaged);
+					}}
 				/>
 				<div className="flex items-center flex-1">
 					<Popup
@@ -133,21 +132,13 @@ export const Header = ({
 							</VSCodeButton>
 						))}
 					<div
-						className={cn(
-							'viewed-button flex ml-10 justify-between checkbox-container items-center',
-							{
-								disabled: changesAccepted,
-							},
-						)}
+						className="viewed-button flex ml-10 justify-between checkbox-container items-center"
 						onClick={(e) => {
 							e.stopPropagation();
 							onViewedChange();
 						}}
 					>
-						<VSCodeCheckbox
-							checked={viewed}
-							disabled={changesAccepted}
-						/>
+						<VSCodeCheckbox checked={viewed} />
 						<p className="my-0 ml-10">Viewed</p>
 					</div>
 				</div>

--- a/intuita-webview/src/jobDiffView/DiffViewer/Diff.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Diff.tsx
@@ -10,7 +10,9 @@ export const useDiffViewer = ({
 	oldFileContent,
 	newFileContent,
 	viewType,
-}: JobDiffViewProps & { viewType: 'inline' | 'side-by-side' }) => {
+}: Omit<JobDiffViewProps, 'staged'> & {
+	viewType: 'inline' | 'side-by-side';
+}) => {
 	const editorRef = useRef<monaco.editor.IStandaloneDiffEditor | null>(null);
 	const [diff, setDiff] = useState<Diff | null>(null);
 	const [height, setHeight] = useState<string>('90vh');

--- a/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
@@ -14,8 +14,7 @@ type Props = JobDiffViewProps & {
 	postMessage: (arg: JobAction) => void;
 	ViewType: 'inline' | 'side-by-side';
 	jobStaged: boolean;
-	onToggleJob(): void;
-	changesAccepted: boolean;
+	onToggleJob(staged: boolean): void;
 };
 
 export const JobDiffView = ({
@@ -29,7 +28,6 @@ export const JobDiffView = ({
 	newFileTitle,
 	title,
 	jobStaged,
-	changesAccepted,
 	postMessage,
 	onToggleJob,
 }: Props) => {
@@ -99,7 +97,6 @@ export const JobDiffView = ({
 					title={title ?? ''}
 					viewType={viewType}
 					jobStaged={jobStaged}
-					changesAccepted={changesAccepted}
 					onToggleJob={onToggleJob}
 					onViewTypeChange={setViewType}
 					onReportIssue={reportIssue}

--- a/intuita-webview/src/jobDiffView/DiffViewer/Header/index.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Header/index.tsx
@@ -2,34 +2,28 @@ import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 
 import { ReactComponent as UnifiedIcon } from '../../../assets/Unified.svg';
 import { ReactComponent as SplitIcon } from '../../../assets/Split.svg';
-import { DiffViewType } from '../../../shared/types';
+import { DiffViewType, JobDiffViewProps } from '../../../shared/types';
 
 import styles from './style.module.css';
 import { vscode } from '../../../shared/utilities/vscode';
-import { JobHash } from '../../../../../src/jobs/types';
 import { CaseHash } from '../../../../../src/cases/types';
 
 type Props = Readonly<{
 	title: string;
 	viewType: DiffViewType;
-	stagedJobHashes: Set<JobHash>;
+	jobs: JobDiffViewProps[];
 	diffId: string;
-	changesAccepted: boolean;
 	onViewChange(value: DiffViewType): void;
 }>;
 
-const Header = ({
-	title,
-	viewType,
-	diffId,
-	stagedJobHashes,
-	onViewChange,
-}: Props) => {
+const Header = ({ title, viewType, diffId, jobs, onViewChange }: Props) => {
 	const handleTitleClick = () => {
 		navigator.clipboard.writeText(title);
 	};
 
-	const jobHashes = Array.from(stagedJobHashes);
+	const stagedJobHashes = jobs
+		.filter((job) => job.staged)
+		.map(({ jobHash }) => jobHash);
 
 	const handleDiscardChanges = () => {
 		vscode.postMessage({
@@ -45,12 +39,16 @@ const Header = ({
 	const handleApplySelected = () => {
 		vscode.postMessage({
 			kind: 'webview.global.applySelected',
-			jobHashes,
+			jobHashes: stagedJobHashes,
 			diffId,
+		});
+
+		vscode.postMessage({
+			kind: 'webview.global.closeView',
 		});
 	};
 
-	const hasStagedJobs = stagedJobHashes.size !== 0;
+	const hasStagedJobs = stagedJobHashes.length !== 0;
 	return (
 		<div className={styles.root}>
 			<div className={styles.title} onClick={handleTitleClick}>

--- a/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
@@ -6,26 +6,22 @@ import { DiffViewType } from '../../shared/types';
 import { useCTLKey } from '../hooks/useKey';
 
 import Header from './Header';
+import { vscode } from '../../shared/utilities/vscode';
 
 type JobDiffViewContainerProps = {
 	postMessage: (arg: JobAction) => void;
 	jobs: JobDiffViewProps[];
 	title: string;
 	diffId: string;
-	changesAccepted: boolean;
 };
 
 export const JobDiffViewContainer = ({
 	title,
 	jobs,
 	diffId,
-	changesAccepted,
 	postMessage,
 }: JobDiffViewContainerProps) => {
 	const [viewType, setViewType] = useState<DiffViewType>('side-by-side');
-	const [stagedJobHashes, setStagedJobHashes] = useState(
-		new Set(jobs.map(({ jobHash }) => jobHash)),
-	);
 
 	useCTLKey('d', () => {
 		setViewType((v) => (v === 'side-by-side' ? 'inline' : 'side-by-side'));
@@ -37,30 +33,21 @@ export const JobDiffViewContainer = ({
 				onViewChange={setViewType}
 				viewType={viewType}
 				title={title}
-				stagedJobHashes={stagedJobHashes}
+				jobs={jobs}
 				diffId={diffId}
-				changesAccepted={changesAccepted}
 			/>
 
 			{jobs.map((el) => (
 				<JobDiffView
-					changesAccepted={changesAccepted}
 					ViewType={viewType}
 					key={el.jobHash}
 					postMessage={postMessage}
-					jobStaged={stagedJobHashes.has(el.jobHash)}
-					onToggleJob={() => {
-						setStagedJobHashes((prevStagedJobHashes) => {
-							const nextStagedJobHashes = new Set(
-								prevStagedJobHashes,
-							);
-							if (nextStagedJobHashes.has(el.jobHash)) {
-								nextStagedJobHashes.delete(el.jobHash);
-							} else {
-								nextStagedJobHashes.add(el.jobHash);
-							}
-
-							return nextStagedJobHashes;
+					jobStaged={el.staged}
+					onToggleJob={(staged: boolean) => {
+						vscode.postMessage({
+							kind: 'webview.global.stageJob',
+							jobHash: el.jobHash,
+							staged,
 						});
 					}}
 					{...el}

--- a/src/components/jobManager.ts
+++ b/src/components/jobManager.ts
@@ -253,8 +253,7 @@ export class JobManager {
 				(job.kind === JobKind.rewriteFile ||
 					job.kind === JobKind.moveAndRewriteFile ||
 					job.kind === JobKind.createFile ||
-					job.kind === JobKind.moveFile ||
-					job.kind === JobKind.copyFile) &&
+					job.kind === JobKind.moveFile) &&
 				job.newContentUri
 			) {
 				messages.push({

--- a/src/components/webview/WebviewPanel.ts
+++ b/src/components/webview/WebviewPanel.ts
@@ -56,7 +56,7 @@ export abstract class IntuitaWebviewPanel {
 
 		this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
 
-		this._attachExtensionEventListeners();
+		this._attachExtensionEventListeners?.();
 		this._attachWebviewEventListeners?.();
 	}
 
@@ -68,7 +68,7 @@ export abstract class IntuitaWebviewPanel {
 		this._panel.title = title;
 	};
 
-	protected abstract _attachExtensionEventListeners(): void;
+	protected _attachExtensionEventListeners?(): void;
 	protected _attachWebviewEventListeners?(): void;
 
 	protected _postMessage(message: WebviewMessage) {

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -28,6 +28,7 @@ export type JobDiffViewProps = Readonly<{
 	newFileTitle: string | null;
 	title: string | null;
 	actions?: JobAction[];
+	staged: boolean;
 }>;
 
 export type CommitChangesFormData = Readonly<{
@@ -150,10 +151,6 @@ export type WebviewMessage =
 			jobHash: JobHash;
 	  }>
 	| Readonly<{
-			kind: 'webview.diffView.setChangesAccepted';
-			value: boolean;
-	  }>
-	| Readonly<{
 			kind: 'webview.createIssue.submittingIssue';
 			value: boolean;
 	  }>
@@ -238,6 +235,11 @@ export type WebviewResponse =
 			diffId: string;
 	  }>
 	| Readonly<{
+			kind: 'webview.global.stageJob';
+			jobHash: JobHash;
+			staged: boolean;
+	  }>
+	| Readonly<{
 			kind: 'webview.campaignManager.caseSelected';
 			hash: CaseHash;
 	  }>
@@ -289,7 +291,6 @@ export type View =
 			viewId: 'jobDiffView';
 			viewProps: {
 				diffId: string;
-				changesAccepted: boolean;
 				title: string;
 				data: JobDiffViewProps[];
 			};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,14 +209,9 @@ export async function activate(context: vscode.ExtensionContext) {
 					const { title, data } = viewProps;
 					panelInstance.setTitle(`${title} (${data.length})`);
 
-					const caseAccepted = caseManager.isCaseAccepted(
-						String(caseHash) as CaseHash,
-					);
-
 					panelInstance.setView({
 						viewId: 'jobDiffView',
 						viewProps: {
-							changesAccepted: caseAccepted,
 							diffId: String(caseHash) as CaseHash,
 							title,
 							data,
@@ -758,8 +753,6 @@ export async function activate(context: vscode.ExtensionContext) {
 					if (diffViewPanel === null) {
 						return;
 					}
-
-					diffViewPanel.setChangesAccepted(true);
 				} catch (e) {
 					const message = e instanceof Error ? e.message : String(e);
 					vscode.window.showErrorMessage(message);


### PR DESCRIPTION
 - store staged jobs state outside of webview (fixes checkboxes state lost when reopening diff view)
 - do not collapse/expand job when checkbox clicked
 - remove unused code