### PR TITLE
INT-919 central management of opened IDs

### DIFF
--- a/intuita-webview/src/codemodList/TreeView/Tree.tsx
+++ b/intuita-webview/src/codemodList/TreeView/Tree.tsx
@@ -1,27 +1,22 @@
 import ReactTreeView from 'react-treeview';
-import { ReactNode, memo, useState } from 'react';
-import { CodemodTreeNode } from '../../shared/types';
+import { ReactNode } from 'react';
+import { CodemodHash, CodemodTreeNode } from '../../shared/types';
 
 type Props = {
 	depth: number;
+	openedIds: ReadonlySet<CodemodHash>;
 	node: CodemodTreeNode<string>;
 	renderItem({
 		node,
 		depth,
-		open,
-		setIsOpen,
 	}: {
 		node: CodemodTreeNode<string>;
 		depth: number;
-		open: boolean;
-		setIsOpen: (value: boolean) => void;
 	}): ReactNode;
 };
 
-const Tree = ({ node, depth, renderItem }: Props) => {
-	const [open, setIsOpen] = useState(depth === 0);
-
-	const treeItem = renderItem({ node, depth, open, setIsOpen });
+const Tree = ({ node, openedIds, depth, renderItem }: Props) => {
+	const treeItem = renderItem({ node, depth });
 
 	if (!node.children || node.children.length === 0) {
 		return <>{treeItem}</>;
@@ -36,6 +31,7 @@ const Tree = ({ node, depth, renderItem }: Props) => {
 						node={child}
 						depth={depth + 1}
 						renderItem={renderItem}
+						openedIds={openedIds}
 					/>
 				))}
 			</>
@@ -43,18 +39,19 @@ const Tree = ({ node, depth, renderItem }: Props) => {
 	}
 
 	return (
-		<ReactTreeView collapsed={!open} nodeLabel={treeItem}>
+		<ReactTreeView collapsed={!openedIds.has(node.id)} nodeLabel={treeItem}>
 			{node.children.map((child) => (
 				<Tree
 					key={child.id}
 					node={child}
 					depth={depth + 1}
 					renderItem={renderItem}
+					openedIds={openedIds}
 				/>
 			))}
 		</ReactTreeView>
 	);
 };
 
-export default memo(Tree);
+export default Tree;
 export type { CodemodTreeNode };

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -50,6 +50,23 @@ const TreeView = ({
 	const [editExecutionPath, setEditExecutionPath] =
 		useState<CodemodTreeNode<string> | null>(null);
 	const [executionStack, setExecutionStack] = useState<CodemodHash[]>([]);
+	const [openedIds, setOpenedIds] = useState<ReadonlySet<CodemodHash>>(
+		new Set(node ? [node.id] : []),
+	);
+
+	const flipTreeItem = (id: CodemodHash) => {
+		setOpenedIds((oldSet) => {
+			const newSet = new Set(oldSet);
+
+			if (oldSet.has(id)) {
+				newSet.delete(id);
+			} else {
+				newSet.add(id);
+			}
+
+			return newSet;
+		});
+	};
 
 	const onHalt = useCallback(() => {
 		if (!executionStack.length) {
@@ -114,19 +131,13 @@ const TreeView = ({
 	const renderItem = ({
 		node,
 		depth,
-		open,
-		setIsOpen,
-		focusedNodeId,
-		setFocusedNodeId,
 	}: {
 		node: CodemodTreeNode<string>;
 		depth: number;
-		open: boolean;
-		setIsOpen: (value: boolean) => void;
-		focusedNodeId: string;
-		setFocusedNodeId: (value: string) => void;
 	}) => {
-		const icon = getIcon(node.iconName ?? null, open);
+		const opened = openedIds.has(node.id);
+
+		const icon = getIcon(node.iconName ?? null, opened);
 
 		const actionButtons = (node.actions ?? []).map((action) => (
 			// eslint-disable-next-line jsx-a11y/anchor-is-valid
@@ -195,11 +206,11 @@ const TreeView = ({
 				icon={icon}
 				depth={depth}
 				kind={node.kind}
-				open={open}
+				open={opened}
 				focused={node.id === focusedNodeId}
 				onClick={() => {
 					handleClick(node);
-					setIsOpen(!open);
+					flipTreeItem(node.id);
 					setFocusedNodeId(node.id);
 				}}
 				actionButtons={getActionButtons()}
@@ -259,10 +270,9 @@ const TreeView = ({
 
 			<Tree
 				node={node}
-				renderItem={(props) =>
-					renderItem({ ...props, setFocusedNodeId, focusedNodeId })
-				}
+				renderItem={renderItem}
 				depth={0}
+				openedIds={openedIds}
 			/>
 		</div>
 	);


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-919/provide-the-uri-to-select-a-specific-codemod-in-public-registry-in-the

To support opening arbitrary codemods from the URI, we need to control the opening state of tree items already at the tree view level.

This means that the `Tree` component is stateless now and no longer memoized.