### PR TITLE
Provide the URI to select a specific codemod in public registry in the Intuita VSCode Extension

### DIFF
--- a/intuita-webview/src/codemodList/App.tsx
+++ b/intuita-webview/src/codemodList/App.tsx
@@ -42,7 +42,7 @@ function App() {
 			<Container
 				defaultExpanded
 				headerTitle="Public Codemods"
-				className="content-border-top  h-full"
+				className="content-border-top h-full"
 			>
 				<div>
 					{E.isRight(publicCodemods) &&

--- a/intuita-webview/src/codemodList/App.tsx
+++ b/intuita-webview/src/codemodList/App.tsx
@@ -48,7 +48,6 @@ function App() {
 					{E.isRight(publicCodemods) &&
 						publicCodemods.right !== null && (
 							<TreeView
-								emptyTreeMessage={null}
 								response={pathEditResponse}
 								node={publicCodemods.right}
 							/>

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -74,7 +74,7 @@ type InitializerArgument = Readonly<{
 }>;
 
 type Action = Readonly<{
-	kind: 'focus';
+	kind: 'focus' | 'flip';
 	id: CodemodHash;
 }>;
 
@@ -91,7 +91,23 @@ const reducer = (state: State, action: Action): State => {
 		};
 	}
 
-	return state; // default state;
+	if (action.kind === 'flip') {
+		const openedIds = new Set(state.openedIds);
+
+		if (openedIds.has(action.id)) {
+			openedIds.delete(action.id);
+		} else {
+			openedIds.add(action.id);
+		}
+
+		return {
+			node: state.node,
+			openedIds,
+			focusedId: action.id,
+		};
+	}
+
+	return state;
 };
 
 const initializer = ({ node, focusedId }: InitializerArgument): State => {
@@ -206,20 +222,6 @@ const TreeView = ({ node, response }: Props) => {
 		[],
 	);
 
-	const flipTreeItem = (id: CodemodHash) => {
-		setOpenedIds((oldSet) => {
-			const newSet = new Set(oldSet);
-
-			if (oldSet.has(id)) {
-				newSet.delete(id);
-			} else {
-				newSet.add(id);
-			}
-
-			return newSet;
-		});
-	};
-
 	const renderItem = ({
 		node,
 		depth,
@@ -302,10 +304,9 @@ const TreeView = ({ node, response }: Props) => {
 				focused={node.id === state.focusedId}
 				onClick={() => {
 					handleClick(node);
-					flipTreeItem(node.id);
 
 					dispatch({
-						kind: 'focus',
+						kind: 'flip',
 						id: node.id,
 					});
 				}}

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -227,7 +227,7 @@ const TreeView = ({ node, response }: Props) => {
 		node: CodemodTreeNode<string>;
 		depth: number;
 	}) => {
-		const opened = openedIds.has(node.id);
+		const opened = state.openedIds.has(node.id);
 
 		const icon = getIcon(node.iconName ?? null, opened);
 
@@ -299,11 +299,15 @@ const TreeView = ({ node, response }: Props) => {
 				depth={depth}
 				kind={node.kind}
 				open={opened}
-				focused={node.id === focusedNodeId}
+				focused={node.id === state.focusedId}
 				onClick={() => {
 					handleClick(node);
 					flipTreeItem(node.id);
-					setFocusedNodeId(node.id);
+
+					dispatch({
+						kind: 'focus',
+						id: node.id,
+					});
 				}}
 				actionButtons={getActionButtons()}
 			/>
@@ -360,7 +364,7 @@ const TreeView = ({ node, response }: Props) => {
 				node={node}
 				renderItem={renderItem}
 				depth={0}
-				openedIds={openedIds}
+				openedIds={state.openedIds}
 			/>
 		</div>
 	);

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -67,7 +67,7 @@ const TreeView = ({ node, response }: Props) => {
 		new Set([node.id]),
 	);
 	const [focusedNodeId, setFocusedNodeId] = useState<CodemodHash | null>(
-		null,
+		window.INITIAL_STATE.focusedCodemodHashDigest ?? null,
 	);
 	const [editExecutionPath, setEditExecutionPath] =
 		useState<CodemodTreeNode<string> | null>(null);
@@ -130,6 +130,20 @@ const TreeView = ({ node, response }: Props) => {
 		return () => {
 			window.removeEventListener('message', handler);
 		};
+	}, [node]);
+
+	useEffect(() => {
+		if (focusedNodeId === null) {
+			return;
+		}
+
+		setOpenedIds((oldOpenedIds) => {
+			const newOpenedIds = new Set(oldOpenedIds);
+
+			containsCodemodHashDigest(node, focusedNodeId, newOpenedIds);
+
+			return newOpenedIds;
+		});
 	}, [node]);
 
 	const handleClick = useCallback((node: CodemodTreeNode<string>) => {

--- a/intuita-webview/src/sourceControl/App.tsx
+++ b/intuita-webview/src/sourceControl/App.tsx
@@ -6,6 +6,7 @@ import CreateIssue from './CreateIssueView';
 import CommitView from './CommitView';
 
 import type {
+	CodemodHash,
 	View,
 	WebviewMessage,
 } from '../../../src/components/webview/webviewEvents';
@@ -14,6 +15,7 @@ declare global {
 	interface Window {
 		INITIAL_STATE: {
 			userId: string | null;
+			focusedCodemodHashDigest?: CodemodHash | null | undefined;
 		};
 	}
 }

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -77,6 +77,8 @@ export const enum MessageKind {
 
 	beforePRCreated = 33,
 	afterPRCreated = 34,
+
+	focusCodemod = 35,
 }
 
 export type Engine = 'node' | 'rust';
@@ -260,6 +262,10 @@ export type Message =
 	  }>
 	| Readonly<{
 			kind: MessageKind.afterPRCreated;
+	  }>
+	| Readonly<{
+			kind: MessageKind.focusCodemod;
+			codemodHashDigest: CodemodHash;
 	  }>;
 
 type EmitterMap<K extends MessageKind> = {

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -30,6 +30,8 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 	__extensionPath: Uri;
 	__webviewResolver: WebviewResolver | null = null;
 	__engineBootstrapped = false;
+	__focusedCodemodHashDigest: CodemodHash | null = null;
+
 	readonly __eventEmitter = new EventEmitter<void>();
 
 	constructor(
@@ -54,7 +56,7 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 		);
 
 		this.__messageBus.subscribe(MessageKind.focusCodemod, (message) => {
-			this.__view?.show();
+			this.__focusedCodemodHashDigest = message.codemodHashDigest;
 
 			this.__postMessage({
 				kind: 'webview.codemods.focusCodemod',
@@ -104,16 +106,14 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 		this.__webviewResolver?.resolveWebview(
 			this.__view.webview,
 			'codemodList',
-			'{}',
+			JSON.stringify({
+				focusedCodemodHashDigest: this.__focusedCodemodHashDigest,
+			}),
 		);
 	}
 
 	private __postMessage(message: WebviewMessage) {
-		if (!this.__view) {
-			return;
-		}
-
-		this.__view.webview.postMessage(message);
+		this.__view?.webview.postMessage(message);
 	}
 
 	private __watchPackageJson() {
@@ -131,7 +131,9 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 		this.__webviewResolver?.resolveWebview(
 			webviewView.webview,
 			'codemodList',
-			'{}',
+			JSON.stringify({
+				focusedCodemodHashDigest: this.__focusedCodemodHashDigest,
+			}),
 		);
 		this.__view = webviewView;
 

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -53,6 +53,15 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 			this.handleCodemodExecutionProgress.bind(this),
 		);
 
+		this.__messageBus.subscribe(MessageKind.focusCodemod, (message) => {
+			this.__view?.show();
+
+			this.__postMessage({
+				kind: 'webview.codemods.focusCodemod',
+				codemodHashDigest: message.codemodHashDigest,
+			});
+		});
+
 		this.__messageBus.subscribe(MessageKind.codemodSetExecuted, () => {
 			this.__postMessage({
 				kind: 'webview.global.codemodExecutionHalted',
@@ -230,7 +239,6 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 		}
 
 		if (message.kind === 'webview.global.afterWebviewMounted') {
-			this.getCodemodTree('recommended');
 			this.getCodemodTree('public');
 		}
 	};

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -184,6 +184,10 @@ export type WebviewMessage =
 	  }>
 	| Readonly<{
 			kind: 'webview.global.codemodExecutionHalted';
+	  }>
+	| Readonly<{
+			kind: 'webview.codemods.focusCodemod';
+			codemodHashDigest: CodemodHash;
 	  }>;
 
 export type WebviewResponse =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1411,6 +1411,7 @@ export async function activate(context: vscode.ExtensionContext) {
 				const searchParams = new URLSearchParams(uri.query);
 				const base64UrlEncodedContent = searchParams.get('c');
 				const userId = searchParams.get('userId');
+				const codemodHashDigest = searchParams.get('chd');
 
 				if (base64UrlEncodedContent) {
 					const buffer = Buffer.from(
@@ -1427,9 +1428,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					);
 
 					vscode.window.showTextDocument(document);
-				}
-
-				if (userId) {
+				} else if (userId) {
 					try {
 						userService.linkUsersIntuitaAccount(userId);
 					} catch (e) {
@@ -1447,6 +1446,15 @@ export async function activate(context: vscode.ExtensionContext) {
 							}
 						}
 					}
+				} else if (codemodHashDigest !== null) {
+					messageBus.publish({
+						kind: MessageKind.focusCodemod,
+						codemodHashDigest: codemodHashDigest as CodemodHash,
+					});
+
+					vscode.commands.executeCommand(
+						'workbench.view.extension.intuitaViewId',
+					);
 				}
 			},
 		}),


### PR DESCRIPTION
Changes:
* the state in the tree view is controlled using a reducer that contains the focusedId and openedIds with two actions: flip and focus
* the URI handler passes information to the webview using INITIAL_DATA and message bus boundary; this allows the URI to focus on the proper codemod regardless if the webview has been initialized or not

you can try the following URL to test:
`vscode://intuita.intuita-vscode-extension/test?chd=oU68MgnhDvq08nBVNTQK8fouqGI`

The codemod hash digest are Base64URL-encoded on purpose so these links are possible.