### PR TITLE
Fix showing relevant diff view on focusing folder

### DIFF
--- a/intuita-webview/src/jobDiffView/App.tsx
+++ b/intuita-webview/src/jobDiffView/App.tsx
@@ -57,9 +57,9 @@ function App() {
 				);
 
 				const element =
-					document.getElementById(
-						`diffViewer-${view.viewProps.diffId}`,
-					) ?? null;
+					document.getElementsByClassName(
+						'ReactVirtualized__Grid__innerScrollContainer',
+					)[0] ?? null;
 
 				if (element === null) {
 					return;

--- a/intuita-webview/src/jobDiffView/Components/Collapsable.tsx
+++ b/intuita-webview/src/jobDiffView/Components/Collapsable.tsx
@@ -4,7 +4,6 @@ import './Collapsable.css';
 import cn from 'classnames';
 
 type CollapsableProps = Readonly<{
-	id: string;
 	defaultExpanded: boolean;
 	headerComponent: React.ReactNode;
 	headerClassName?: string;
@@ -17,7 +16,6 @@ type CollapsableProps = Readonly<{
 }>;
 
 export const Collapsable = ({
-	id,
 	onToggle,
 	defaultExpanded: defaultCollapsed,
 	headerSticky,
@@ -29,7 +27,7 @@ export const Collapsable = ({
 	children,
 }: CollapsableProps) => {
 	return (
-		<div className={cn('collapsable', className)} id={id}>
+		<div className={cn('collapsable', className)}>
 			<div
 				className={cn(headerClassName, {
 					collapsable__header: true,

--- a/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
@@ -61,7 +61,6 @@ export const JobDiffView = ({
 			className="px-5 pb-2-5 "
 		>
 			<Collapsable
-				id={newFileTitle ?? ''}
 				defaultExpanded={expanded}
 				onToggle={onToggle}
 				className="overflow-hidden rounded "

--- a/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
@@ -242,10 +242,7 @@ export const JobDiffViewContainer = ({
 	};
 
 	return (
-		<div
-			className="w-full h-full flex flex-col "
-			id={`diffViewer-${diffId}`}
-		>
+		<div className="w-full h-full flex flex-col">
 			<Header
 				onViewChange={setViewType}
 				viewType={viewType}
@@ -280,7 +277,7 @@ export const JobDiffViewContainer = ({
 							>
 								{({ registerChild }) => {
 									return (
-										<div style={style}>
+										<div style={style} id={el.newFileTitle ?? ''}>
 											<JobDiffView
 												theme={theme}
 												containerRef={registerChild}

--- a/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
@@ -277,7 +277,10 @@ export const JobDiffViewContainer = ({
 							>
 								{({ registerChild }) => {
 									return (
-										<div style={style} id={el.newFileTitle ?? ''}>
+										<div
+											style={style}
+											id={el.newFileTitle ?? ''}
+										>
 											<JobDiffView
 												theme={theme}
 												containerRef={registerChild}


### PR DESCRIPTION
After #377 (which led to changes in HTML structure of diff view), the function of showing the relevant file on focusing on folder in "Change Explorer" panel is broken. This PR fixes it.