### PR TITLE
Remove outline CSS that happens/remains on/after pressing a button

### DIFF
--- a/intuita-webview/src/communityView/style.module.css
+++ b/intuita-webview/src/communityView/style.module.css
@@ -7,12 +7,17 @@
 .button {
 	width: 100%;
 	height: 24px;
-	outline: none;
 	display: block;
 	border-radius: 0px;
 }
 
-.button:focus {
+/* VSCodeButton creates a shadow <button /> element with part='control' */
+.button::part(control) {
+	width: 100%;
+	justify-content: flex-start;
+}
+
+.button::part(control):focus {
 	outline: none;
 }
 

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.css
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.css
@@ -37,6 +37,10 @@
 	color: #3ac06b;
 }
 
+.vscode-button::part(control):focus {
+	outline: none;
+}
+
 .icon-container {
 	background-color: var(--vscode-editor-background);
 	border-radius: 5px;

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.css
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.css
@@ -37,6 +37,7 @@
 	color: #3ac06b;
 }
 
+/* VSCodeButton creates a shadow <button /> element with part='control' */
 .vscode-button::part(control):focus {
 	outline: none;
 }

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -109,6 +109,7 @@ export const Header = ({
 					<VSCodeButton
 						onClick={handleCopyFileName}
 						appearance="icon"
+						className="vscode-button"
 					>
 						<CopyIcon className="copy-icon" />
 					</VSCodeButton>


### PR DESCRIPTION
### Linear: https://linear.app/intuita/issue/INT-1022/remove-outline-css-that-happensremains-onafter-pressing-a-button

### Before

![Screenshot 2023-05-15 at 09 27 59](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/3d6b002b-2e82-4750-ab13-01191065e89e)


### After

Claap: https://app.claap.io/intuita/remove-outline-css-that-happens-remains-on-after-pressing-a-button-c-BT2DRbCjzO-nkdZwKck2GFa