### PR TITLE
Change UI for Copy Job Kind in Diff View

### DIFF
--- a/intuita-webview/src/codemodList/components/Container.css
+++ b/intuita-webview/src/codemodList/components/Container.css
@@ -46,7 +46,7 @@
 	top: 0;
 }
 
-.collpasableContent {
+.collapsableContent {
 	padding: 0;
 }
 

--- a/intuita-webview/src/codemodList/components/Container.tsx
+++ b/intuita-webview/src/codemodList/components/Container.tsx
@@ -40,7 +40,7 @@ export const Container = ({
 				className="codemodListCollapsable"
 				headerChevronClassName="codemodListCollapsableArrow"
 				headerClassName="collapsableHeader"
-				contentClassName="collpasableContent"
+				contentClassName="collapsableContent"
 				onToggle={(expanded) => {
 					setExpanded(expanded);
 					onToggle?.(expanded);

--- a/intuita-webview/src/codemodList/components/Container.tsx
+++ b/intuita-webview/src/codemodList/components/Container.tsx
@@ -47,7 +47,7 @@ export const Container = ({
 				}}
 				defaultExpanded={defaultExpanded}
 				headerComponent={
-					<>{headerTitle && <Header title={headerTitle} />}</>
+					headerTitle ? <Header title={headerTitle} /> : null
 				}
 			>
 				{children}

--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -9,30 +9,16 @@ import Popover from '../../shared/Popover';
 import { vscode } from '../../shared/utilities/vscode';
 
 type ContainerProps = Readonly<{
-	oldFileName: string | null;
-	newFileName: string | null;
-	viewType: 'inline' | 'side-by-side';
 	children?: React.ReactNode;
 }>;
 
 export const Container = forwardRef<HTMLDivElement, ContainerProps>(
-	({ oldFileName, newFileName, children, viewType }: ContainerProps, ref) => {
+	({ children }: ContainerProps, ref) => {
 		return (
 			<div
 				className="flex  flex-wrap w-full container flex-col"
 				ref={ref}
 			>
-				{viewType === 'side-by-side' && newFileName && oldFileName && (
-					<div className="flex flex-row w-full">
-						<div className="w-half ml-50">
-							<p>{oldFileName}</p>
-						</div>
-						<div className="w-half ml-30">
-							<p>{newFileName}</p>
-						</div>
-					</div>
-				)}
-
 				<div className="flex flex-wrap flex-col w-full">{children}</div>
 			</div>
 		);
@@ -62,6 +48,7 @@ export const Header = ({
 	diff,
 	title,
 	jobKind,
+	oldFileTitle,
 	children,
 	viewed,
 	actions,
@@ -103,9 +90,18 @@ export const Header = ({
 							{jobKindText}
 						</h4>
 					) : null}
-					<h4 className="my-0 ml-1 diff-title align-self-center">
-						{title}
-					</h4>
+					<Popover
+						disabled={
+							(jobKind as unknown as JobKind) !== JobKind.copyFile
+						}
+						trigger={
+							<h4 className="my-0 ml-1 diff-title align-self-center">
+								{title}
+							</h4>
+						}
+						popoverText={`Copied from ${oldFileTitle}`}
+						offsetY={0}
+					/>
 					<VSCodeButton
 						onClick={handleCopyFileName}
 						appearance="icon"
@@ -175,7 +171,6 @@ export const Header = ({
 const getJobKindText = (jobKind: JobKind): string => {
 	switch (jobKind) {
 		case JobKind.copyFile:
-			return '(copied)';
 		case JobKind.createFile:
 			return '(created)';
 		case JobKind.deleteFile:

--- a/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
@@ -101,11 +101,7 @@ export const JobDiffView = ({
 					/>
 				}
 			>
-				<Container
-					viewType={ViewType}
-					oldFileName={oldFileTitle}
-					newFileName={newFileTitle}
-				>
+				<Container>
 					<DiffComponent
 						theme={theme}
 						height={height}

--- a/intuita-webview/src/shared/Popover/index.tsx
+++ b/intuita-webview/src/shared/Popover/index.tsx
@@ -19,7 +19,7 @@ const Popover = ({ trigger, popoverText, ...others }: Props) => {
 			mouseLeaveDelay={30} // 100ms by default; Ref: https://react-popup.elazizi.com/component-api#mouseleavedelay
 			trigger={trigger}
 			position={['top right', 'right center']}
-			offsetY={30}
+			offsetY={30} // 0 by default
 			lockScroll
 			on={['hover', 'focus']}
 			contentStyle={{ display: 'flex', alignItems: 'center' }}


### PR DESCRIPTION
### Changes
- in file diff view header, let's say "(created)" instead of "(copied)"
- Create a popover that appears when hovering over the new file name. The Popover should say "Copied from oldFileName"

#### Linear: https://linear.app/intuita/issue/INT-974/change-ui-for-copy-job-kind-in-diff-view
#### Claap: https://app.claap.io/intuita/change-ui-for-copy-job-kind-in-diff-view-c-BT2DRbCjzO-t8Dzh_FfrDUs