### PR TITLE
Improvements to Edit Path item

### DIFF
--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -43,6 +43,7 @@ const TreeItem = ({
 	depth,
 	executionPath,
 }: Props) => {
+	const repoName = rootPath.split('/').slice(-1)[0] ?? '';
 	const [hideActionsGroup, setHideActionsGroup] = useState(false);
 	const error: string | null = pipe(
 		O.fromNullable(executionPath),
@@ -70,8 +71,8 @@ const TreeItem = ({
 
 	const targetPath =
 		path.replace(rootPath, '').length === 0
-			? './'
-			: path.replace(rootPath, '.');
+			? `${repoName}/`
+			: path.replace(rootPath, repoName);
 
 	const onEditStart = useCallback(() => {
 		setHideActionsGroup(true);

--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -44,7 +44,8 @@ const TreeItem = ({
 	executionPath,
 }: Props) => {
 	const repoName = rootPath.split('/').slice(-1)[0] ?? '';
-	const [hideActionsGroup, setHideActionsGroup] = useState(false);
+	const [editingPath, setEditingPath] = useState(false);
+
 	const error: string | null = pipe(
 		O.fromNullable(executionPath),
 		O.fold(
@@ -75,15 +76,15 @@ const TreeItem = ({
 			: path.replace(rootPath, repoName);
 
 	const onEditStart = useCallback(() => {
-		setHideActionsGroup(true);
+		setEditingPath(true);
 	}, []);
 
 	const onEditEnd = useCallback(() => {
-		setHideActionsGroup(false);
+		setEditingPath(false);
 	}, []);
 
 	const onEditCancel = useCallback(() => {
-		setHideActionsGroup(false);
+		setEditingPath(false);
 	}, []);
 
 	return (
@@ -104,31 +105,42 @@ const TreeItem = ({
 					}),
 				}}
 			/>
-			{hasChildren ? (
-				<div className={styles.codicon}>
-					<span
-						className={cn('codicon', {
-							'codicon-chevron-right': !open,
-							'codicon-chevron-down': open,
-						})}
-					/>
-				</div>
-			) : null}
-			{kind === 'codemodItem' && description && (
-				<Popover
-					trigger={<div className={styles.icon}>{icon}</div>}
-					position={['bottom left', 'top left']}
-					mouseEnterDelay={300}
-					popoverText={description}
-				/>
-			)}
-			{(kind === 'path' || !description) && (
-				<div className={styles.icon}>{icon}</div>
+			{!editingPath && (
+				<>
+					{hasChildren ? (
+						<div className={styles.codicon}>
+							<span
+								className={cn('codicon', {
+									'codicon-chevron-right': !open,
+									'codicon-chevron-down': open,
+								})}
+							/>
+						</div>
+					) : null}
+					{kind === 'codemodItem' && description && (
+						<Popover
+							trigger={<div className={styles.icon}>{icon}</div>}
+							position={['bottom left', 'top left']}
+							mouseEnterDelay={300}
+							popoverText={description}
+						/>
+					)}
+					{(kind === 'path' || !description) && (
+						<div className={styles.icon}>{icon}</div>
+					)}
+				</>
 			)}
 			<div className="flex w-full flex-col">
 				<span className={styles.label}>
-					{label}
-					<span className={styles.directorySelector}>
+					{!editingPath && <span>{label}</span>}
+					<span
+						className={styles.directorySelector}
+						style={{
+							...(editingPath && {
+								display: 'flex',
+							}),
+						}}
+					>
 						{kind === 'codemodItem' && executionPath && (
 							<DirectorySelector
 								defaultValue={targetPath}
@@ -142,14 +154,14 @@ const TreeItem = ({
 						)}
 					</span>
 				</span>
+
 				{progressBar}
 			</div>
-			<div
-				className={styles.actions}
-				style={{ ...(hideActionsGroup && { display: 'none' }) }}
-			>
-				{actionButtons.map((el) => el)}
-			</div>
+			{!editingPath && (
+				<div className={styles.actions}>
+					{actionButtons.map((el) => el)}
+				</div>
+			)}
 		</div>
 	);
 };

--- a/intuita-webview/src/codemodList/TreeView/style.module.css
+++ b/intuita-webview/src/codemodList/TreeView/style.module.css
@@ -19,6 +19,10 @@
 	display: none;
 }
 
+.directorySelector {
+	width: 100%;
+}
+
 .root:hover .actions,
 .root:hover .directorySelector {
 	display: flex;

--- a/intuita-webview/src/codemodList/components/DirectorySelector.tsx
+++ b/intuita-webview/src/codemodList/components/DirectorySelector.tsx
@@ -44,6 +44,10 @@ export const DirectorySelector = ({
 
 	const handleChange = (e: Event | React.FormEvent<HTMLElement>) => {
 		const newValue = (e.target as HTMLInputElement).value;
+		if (!newValue.startsWith(repoName)) {
+			setValue(`${repoName}/`);
+			return;
+		}
 		setValue(newValue);
 	};
 
@@ -122,7 +126,10 @@ export const DirectorySelector = ({
 					}}
 					className={styles.targetPathButton}
 				>
-					<span className={styles.label}>{defaultValue}</span>
+					<span className={styles.label}>
+						<em>{repoName}</em>
+						{defaultValue.replace(repoName, '')}
+					</span>
 				</VSCodeButton>
 			}
 			popoverText="Codemod's target path. Click to edit."

--- a/intuita-webview/src/codemodList/components/DirectorySelector.tsx
+++ b/intuita-webview/src/codemodList/components/DirectorySelector.tsx
@@ -27,6 +27,7 @@ export const DirectorySelector = ({
 	onEditCancel,
 	error,
 }: Props) => {
+	const repoName = rootPath.split('/').slice(-1)[0] ?? '';
 	const [value, setValue] = useState(defaultValue);
 	const [showErrorStyle, setShowErrorStyle] = useState(false);
 	const [editing, setEditing] = useState(false);
@@ -35,7 +36,7 @@ export const DirectorySelector = ({
 		vscode.postMessage({
 			kind: 'webview.codemodList.updatePathToExecute',
 			value: {
-				newPath: value.replace('.', rootPath),
+				newPath: value.replace(repoName, rootPath),
 				codemodHash,
 			},
 		});
@@ -60,8 +61,8 @@ export const DirectorySelector = ({
 		}
 
 		if (event.key === 'Enter') {
-			if (value.length < 2) {
-				// "./" (default path) should always be there
+			if (!value.startsWith(repoName)) {
+				// path must start with repo name
 				handleCancel();
 				return;
 			}


### PR DESCRIPTION
### Changes
1. Execution path starts with repo name. e.g., `cal.com/` instead of `./`
2. Italicize repo name in execution path label in button. (in textfield, it's bit more complicated)
3. Even if user no longer hovers over the item, the edit path textfield will be visible.
4. Edit path textfield takes the entire real estate.

### Claap: https://app.claap.io/intuita/improvements-to-the-edith-path-item-c-BT2DRbCjzO-LwivJerHYCg9

### Linear: https://linear.app/intuita/issue/INT-1098/improvements-to-the-edit-path-item