### PR TITLE
INT-1064 ensure that codemods state is persisted

### DIFF
--- a/intuita-webview/src/codemodList/App.tsx
+++ b/intuita-webview/src/codemodList/App.tsx
@@ -59,7 +59,7 @@ function App() {
 					<TreeView
 						node={node}
 						autocompleteItems={autocompleteItems}
-						openedIds={openedIds}
+						openedIds={new Set(openedIds)}
 						focusedId={focusedId}
 					/>
 				),

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -28,7 +28,6 @@ export const containsCodemodHashDigest = (
 	set: Set<CodemodHash>,
 ): boolean => {
 	if (node.id === codemodHashDigest) {
-		set.add(node.id);
 		return true;
 	}
 
@@ -107,16 +106,20 @@ const reducer = (state: State, action: Action): State => {
 	return state;
 };
 
-const initializer = ({ node, focusedId }: InitializerArgument): State => {
-	const openedIds = new Set([node.id]);
+const initializer = ({
+	node,
+	focusedId,
+	openedIds,
+}: InitializerArgument): State => {
+	const newOpenedIds = new Set([...openedIds, node.id]);
 
 	if (focusedId !== null) {
-		containsCodemodHashDigest(node, focusedId, openedIds);
+		containsCodemodHashDigest(node, focusedId, newOpenedIds);
 	}
 
 	return {
 		node,
-		openedIds,
+		openedIds: newOpenedIds,
 		focusedId,
 	};
 };
@@ -138,6 +141,16 @@ const TreeView = ({ node, autocompleteItems, openedIds, focusedId }: Props) => {
 	>([]);
 	const [runningRepomodHash, setRunningRepomodHash] =
 		useState<CodemodHash | null>(null);
+
+	useEffect(() => {
+		vscode.postMessage({
+			kind: 'webview.codemods.setState',
+			openedIds: Array.from(state.openedIds),
+			focusedId: state.focusedId,
+		});
+	}, [state]);
+
+	window.alert(Array.from(state.openedIds));
 
 	const onHalt = useCallback(() => {
 		setRunningRepomodHash(null);

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -28,6 +28,8 @@ export const containsCodemodHashDigest = (
 	set: Set<CodemodHash>,
 ): boolean => {
 	if (node.id === codemodHashDigest) {
+		// set.add(node.id);
+
 		return true;
 	}
 
@@ -149,8 +151,6 @@ const TreeView = ({ node, autocompleteItems, openedIds, focusedId }: Props) => {
 			focusedId: state.focusedId,
 		});
 	}, [state]);
-
-	window.alert(Array.from(state.openedIds));
 
 	const onHalt = useCallback(() => {
 		setRunningRepomodHash(null);

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -159,8 +159,9 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 				viewProps: {
 					codemodTree: this.__codemodTree,
 					autocompleteItems: this.__autocompleteItems,
-					openedIds:
+					openedIds: Array.from(
 						this.__workspaceState.getOpenedCodemodHashDigests(),
+					),
 					focusedId:
 						this.__workspaceState.getFocusedCodemodHashDigest(),
 				},
@@ -312,6 +313,15 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 			);
 
 			this.setView();
+		}
+
+		if (message.kind === 'webview.codemods.setState') {
+			this.__workspaceState.setFocusedCodemodHashDigest(
+				message.focusedId,
+			);
+			this.__workspaceState.setOpenedCodemodHashDigests(
+				new Set(message.openedIds),
+			);
 		}
 	};
 

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -232,7 +232,7 @@ export type WebviewResponse =
 			diffId: string;
 	  }>
 	| Readonly<{
-			kind: 'webview.global.stageJobs';
+			kind: 'webview.global.FstageJobs';
 			jobHashes: JobHash[];
 	  }>
 	| Readonly<{ kind: 'webview.global.showInformationMessage'; value: string }>

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -232,7 +232,7 @@ export type WebviewResponse =
 			diffId: string;
 	  }>
 	| Readonly<{
-			kind: 'webview.global.FstageJobs';
+			kind: 'webview.global.stageJobs';
 			jobHashes: JobHash[];
 	  }>
 	| Readonly<{ kind: 'webview.global.showInformationMessage'; value: string }>

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -268,6 +268,11 @@ export type WebviewResponse =
 			caseHash: CaseHash;
 	  }>
 	| Readonly<{
+			kind: 'webview.codemods.setState';
+			openedIds: ReadonlyArray<CodemodHash>;
+			focusedId: CodemodHash | null;
+	  }>
+	| Readonly<{
 			kind: 'webview.codemodList.haltCodemodExecution';
 			value: CodemodHash;
 	  }>
@@ -336,7 +341,7 @@ export type View =
 			viewProps: {
 				codemodTree: CodemodTree;
 				autocompleteItems: string[];
-				openedIds: ReadonlySet<CodemodHash>;
+				openedIds: ReadonlyArray<CodemodHash>;
 				focusedId: CodemodHash | null;
 			};
 	  }>;


### PR DESCRIPTION
The codemod state (opened menu items and focus) are persisted using the workspace storage.

https://app.claap.io/intuita/codemod-state-persistence-c-BT2DRbCjzO-db-Lv9zx3PHV