### PR TITLE
INT-1121 manage the container state in the root App.tsx file

### DIFF
--- a/intuita-webview/src/codemodList/App.tsx
+++ b/intuita-webview/src/codemodList/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { vscode } from '../shared/utilities/vscode';
 import { WebviewMessage, View } from '../shared/types';
 import TreeView from './TreeView';
-import { Container, LoadingContainer } from './components/Container';
+import { Container } from './components/Container';
 import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
@@ -13,15 +13,16 @@ import SearchBar from '../shared/SearchBar';
 type CodemodView = Extract<View, { viewId: 'codemods' }>;
 
 const loadingContainer = (
-	<LoadingContainer>
+	<div className="loadingContainer">
 		<VSCodeProgressRing className="progressBar" />
-		<span aria-label="loading">Loading ...</span>
-	</LoadingContainer>
+		<span aria-label="loading">Loading...</span>
+	</div>
 );
 
 function App() {
 	const [view, setView] = useState<CodemodView | null>(null);
 	const [searchQuery, setSearchQuery] = useState<string>('');
+	const [expanded, setExpanded] = useState(true);
 
 	useEffect(() => {
 		const handler = (e: MessageEvent<WebviewMessage>) => {
@@ -79,9 +80,10 @@ function App() {
 				placeholder="Search codemods..."
 			/>
 			<Container
-				defaultExpanded
 				headerTitle="Public Codemods"
 				className="publicCodemodsContainer content-border-top h-full"
+				expanded={expanded}
+				setExpanded={setExpanded}
 			>
 				<div>{component}</div>
 			</Container>

--- a/intuita-webview/src/codemodList/components/Container.tsx
+++ b/intuita-webview/src/codemodList/components/Container.tsx
@@ -1,34 +1,22 @@
 import cn from 'classnames';
 import { Collapsable } from '../../shared/Collapsable/Collapsable';
 import './Container.css';
-import { ReactNode, useState } from 'react';
 
-type HeaderProps = {
-	title: string;
-};
-export const Header = ({ title }: HeaderProps) => {
-	return (
-		<div className="header">
-			<p>{title}</p>
-		</div>
-	);
-};
+type Props = Readonly<{
+	className?: string;
+	children: React.ReactNode;
+	headerTitle: string;
+	expanded: boolean;
+	setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+}>;
 
 export const Container = ({
 	className,
 	children,
 	headerTitle,
-	onToggle,
-	defaultExpanded,
-}: {
-	className?: string;
-	children: React.ReactNode;
-	headerTitle: string;
-	defaultExpanded: boolean;
-	onToggle?: (toggle: boolean) => void;
-}) => {
-	const [expanded, setExpanded] = useState(true);
-
+	expanded,
+	setExpanded,
+}: Props) => {
 	return (
 		<div
 			className={cn('container', className, {
@@ -43,19 +31,16 @@ export const Container = ({
 				contentClassName="collapsableContent"
 				onToggle={(expanded) => {
 					setExpanded(expanded);
-					onToggle?.(expanded);
 				}}
-				defaultExpanded={defaultExpanded}
+				defaultExpanded={true}
 				headerComponent={
-					headerTitle ? <Header title={headerTitle} /> : null
+					<div className="header">
+						<p>{headerTitle}</p>
+					</div>
 				}
 			>
 				{children}
 			</Collapsable>
 		</div>
 	);
-};
-
-export const LoadingContainer = ({ children }: { children: ReactNode }) => {
-	return <div className="loadingContainer">{children}</div>;
 };


### PR DESCRIPTION
We want to save the state of the container (Public Codemods) expansion so it survives the destruction of the webview.
This PR is the first step to achieve that, by moving the expansion state to the root component.
In addition, I cleaned up the tech debt by inlining some components like the loading container and the header.