### PR TITLE
INT-1144 use index.json from s3 to fetch codemod metadata

### DIFF
--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -412,7 +412,7 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 				command: {
 					title: 'Show codemod metadata',
 					command: 'intuita.showCodemodMetadata',
-					arguments: [hash],
+					arguments: [name],
 				},
 				uri: name,
 			};

--- a/src/components/webview/VirtualDocumentProvider.ts
+++ b/src/components/webview/VirtualDocumentProvider.ts
@@ -86,8 +86,6 @@ export class TextDocumentContentProvider
 	private __getCodemodMetadata(uri: vscode.Uri): string | null {
 		const { path } = uri;
 
-		console.log(path);
-
 		const name = path.replace(/\.md$/, '');
 		const hash = buildCodemodMetadataHash(name);
 

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -63,7 +63,7 @@ export type CodemodTreeNode = {
 	command?:
 		| Command & {
 				command: 'intuita.showCodemodMetadata';
-				arguments: [CodemodHash];
+				arguments: [string];
 		  };
 	actions?: RunCodemodsCommand[];
 	executionPath?: ExecutionPath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,10 +154,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		),
 	);
 
-	const textContentProvider = new TextDocumentContentProvider(
-		messageBus,
-		engineService,
-	);
+	const textContentProvider = new TextDocumentContentProvider(messageBus);
 
 	context.subscriptions.push(
 		vscode.workspace.registerTextDocumentContentProvider(
@@ -169,21 +166,21 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'intuita.showCodemodMetadata',
-			async (arg0?: CodemodHash) => {
+			async (arg0?: unknown) => {
 				try {
-					const codemodHash = typeof arg0 === 'string' ? arg0 : null;
+					const name = typeof arg0 === 'string' ? arg0 : null;
 
-					if (codemodHash === null) {
-						throw new Error(`Expected codemod hash, got ${arg0}`);
+					if (name === null) {
+						throw new Error(`Expected codemod name, got ${arg0}`);
 					}
 
 					const uri = vscode.Uri.parse(
-						`${CODEMOD_METADATA_SCHEME}:${codemodHash}.md`,
+						`${CODEMOD_METADATA_SCHEME}:${name}.md`,
 					);
 
-					const hasMetadata = textContentProvider.hasMetadata(uri);
+					const metadataExist = textContentProvider.hasMetadata(uri);
 
-					if (!hasMetadata) {
+					if (!metadataExist) {
 						return;
 					}
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -133,3 +133,9 @@ export const streamToString = async (stream: NodeJS.ReadableStream) => {
 
 	return Buffer.concat(chunks).toString('utf-8');
 };
+
+export const buildCodemodMetadataHash = (name: string) =>
+	createHash('ripemd160')
+		.update('README.md')
+		.update(name)
+		.digest('base64url');


### PR DESCRIPTION
Changes:
* fetch files from index.json located on S3 to fetch codemod metadata
* add the `codemodMetadataHash` method to calculate the hash of the readme files

![image](https://github.com/intuita-inc/intuita-vscode-extension/assets/35925521/2d64931a-9d26-4777-a057-6aa31e8e8cf8)
