### PR TITLE
INT-1144 cache the codemod data in the global storage

### DIFF
--- a/src/components/webview/VirtualDocumentProvider.ts
+++ b/src/components/webview/VirtualDocumentProvider.ts
@@ -128,6 +128,8 @@ export class TextDocumentContentProvider
 				.catch((error) => {
 					console.error(error);
 				});
+
+			return 'Wait until the Intuita VSCode Extension loads the codemod description';
 		}
 
 		return data;

--- a/src/components/webview/VirtualDocumentProvider.ts
+++ b/src/components/webview/VirtualDocumentProvider.ts
@@ -129,7 +129,7 @@ export class TextDocumentContentProvider
 					console.error(error);
 				});
 
-			return 'Wait until the Intuita VSCode Extension loads the codemod description';
+			return 'Wait until the Intuita VSCode Extension loads the codemod description.';
 		}
 
 		return data;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		messageBus,
 	);
 
-	const textContentProvider = new TextDocumentContentProvider(messageBus);
+	const textContentProvider = new TextDocumentContentProvider(
+		downloadService,
+		vscode.workspace.fs,
+		context.globalStorageUri,
+		messageBus,
+	);
 
 	context.subscriptions.push(
 		vscode.workspace.registerTextDocumentContentProvider(


### PR DESCRIPTION
https://app.claap.io/intuita/cached-codemod-metadata-c-BT2DRbCjzO-AtPIArf6gn04

If the codemod data have been already retrieved, it will be cached in the global storage.

We have a limitation stemming from the surviving virtual-document editor views - the VSCode Editor loads faster than the extension can claim the `codemod` scheme for the virtual document.