### PR TITLE
INT-1070 remove the nullability checks for webview resolver

### DIFF
--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -36,7 +36,7 @@ import { CaseManager } from '../../cases/caseManager';
 export class CampaignManagerProvider implements WebviewViewProvider {
 	__view: WebviewView | null = null;
 	__extensionPath: Uri;
-	__webviewResolver: WebviewResolver | null = null;
+	__webviewResolver: WebviewResolver;
 	__treeMap = new Map<CaseHash, CaseTreeNode>();
 
 	constructor(
@@ -54,7 +54,7 @@ export class CampaignManagerProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			this.__view.webview,
 			'campaignManager',
 			'{}',
@@ -66,7 +66,7 @@ export class CampaignManagerProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'campaignManager',
 			'{}',

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -59,7 +59,7 @@ const repomodHashes = ['QKEdp-pofR9UnglrKAGDm1Oj6W0'];
 export class CodemodListPanelProvider implements WebviewViewProvider {
 	__view: WebviewView | null = null;
 	__extensionPath: Uri;
-	__webviewResolver: WebviewResolver | null = null;
+	__webviewResolver: WebviewResolver;
 	__engineBootstrapped = false;
 	__codemodTree: CodemodTree = E.right(O.none);
 	__autocompleteItems: string[] = [];
@@ -141,7 +141,7 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			this.__view.webview,
 			'codemodList',
 			JSON.stringify({}),
@@ -258,7 +258,7 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'codemodList',
 			JSON.stringify({}),

--- a/src/components/webview/CommunityProvider.ts
+++ b/src/components/webview/CommunityProvider.ts
@@ -43,12 +43,10 @@ const EXTERNAL_LINKS: ExternalLink[] = [
 
 export class CommunityProvider implements WebviewViewProvider {
 	__view: WebviewView | null = null;
-	__extensionPath: Uri;
-	__webviewResolver: WebviewResolver | null = null;
+	__webviewResolver: WebviewResolver;
 
 	constructor(context: ExtensionContext) {
-		this.__extensionPath = context.extensionUri;
-		this.__webviewResolver = new WebviewResolver(this.__extensionPath);
+		this.__webviewResolver = new WebviewResolver(context.extensionUri);
 	}
 
 	refresh(): void {
@@ -56,7 +54,7 @@ export class CommunityProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			this.__view.webview,
 			'communityView',
 			'{}',
@@ -68,7 +66,7 @@ export class CommunityProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'communityView',
 			'{}',

--- a/src/components/webview/FileExplorerProvider.ts
+++ b/src/components/webview/FileExplorerProvider.ts
@@ -45,7 +45,7 @@ import { DiffWebviewPanel } from './DiffWebviewPanel';
 export class FileExplorerProvider implements WebviewViewProvider {
 	__view: WebviewView | null = null;
 	__extensionPath: Uri;
-	__webviewResolver: WebviewResolver | null = null;
+	__webviewResolver: WebviewResolver;
 	// map between URIs and the Tree Node
 	__treeMap = new Map<string, TreeNode>();
 	// map between URIs and the File Tree Node & the job hash
@@ -72,7 +72,7 @@ export class FileExplorerProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			this.__view.webview,
 			'fileExplorer',
 			'{}',
@@ -84,7 +84,7 @@ export class FileExplorerProvider implements WebviewViewProvider {
 			return;
 		}
 
-		this.__webviewResolver?.resolveWebview(
+		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'fileExplorer',
 			'{}',


### PR DESCRIPTION
The webview resolver is always initialized (in the constructor) thus it is meaningless to check its instance for nullability.