### PR TITLE
Default filepath, / removed, enter does not work

### DIFF
--- a/intuita-webview/src/codemodList/components/DirectorySelector.tsx
+++ b/intuita-webview/src/codemodList/components/DirectorySelector.tsx
@@ -100,13 +100,14 @@ export const DirectorySelector = ({
 
 	const handleChange = (e: Event | React.FormEvent<HTMLElement>) => {
 		ignoreBlurEvent.current = false;
-		const newValue = (e.target as HTMLInputElement).value;
-		if (!newValue.startsWith(repoName)) {
-			setValue(`${repoName}/`);
-			return;
-		}
-		setValue(newValue);
-		onChange(newValue.replace(repoName, rootPath));
+		const newValue = (e.target as HTMLInputElement).value.trim();
+		// path must start with repo name + slash
+		// e.g., "cal.com/"
+		const validString = !newValue.startsWith(`${repoName}/`)
+			? `${repoName}/`
+			: newValue;
+		setValue(validString);
+		onChange(validString.replace(repoName, rootPath));
 	};
 
 	const handleCancel = () => {


### PR DESCRIPTION
#### Linear: https://linear.app/intuita/issue/INT-1161/default-filepath-removed-enter-does-not-work
#### Claap: https://app.claap.io/intuita/default-filepath-removed-enter-does-not-work-c-BT2DRbCjzO-MjeG39T-QXEb
#### Changes

Ensure that path always starts with repo name + slash. User can't override this restriction.