### PR TITLE
INT-1070 implement the Intuita Errors panel

### DIFF
--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -12,10 +12,10 @@ import type {
 import { vscode } from '../shared/utilities/vscode';
 import { ExecutionError } from '../../../src/errors/types';
 
-type ErrorView = Extract<View, { viewId: 'errors' }>;
+type ViewProps = Extract<View, { viewId: 'errors' }>['viewProps'];
 
 const header = (
-	<VSCodeDataGridRow row-type="header">
+	<VSCodeDataGridRow row-type="sticky-header">
 		<VSCodeDataGridCell cell-type="columnheader" grid-column="1">
 			Kind
 		</VSCodeDataGridCell>
@@ -58,7 +58,9 @@ const buildExecutionErrorRow = (
 };
 
 export const App = () => {
-	const [view, setView] = useState<ErrorView | null>(null);
+	const [viewProps, setViewProps] = useState<ViewProps>(
+		(window as any).INITIAL_STATE.viewProps, // TODO fix types
+	);
 
 	useEffect(() => {
 		const handler = (e: MessageEvent<WebviewMessage>) => {
@@ -66,7 +68,7 @@ export const App = () => {
 
 			if (message.kind === 'webview.global.setView') {
 				if (message.value.viewId === 'errors') {
-					setView(message.value);
+					setViewProps(message.value.viewProps);
 				}
 			}
 		};
@@ -79,7 +81,9 @@ export const App = () => {
 		};
 	}, []);
 
-	if (!view) {
+	const { caseHash, executionErrors } = viewProps;
+
+	if (caseHash === null) {
 		return (
 			<main>
 				<p className={styles.welcomeMessage}>
@@ -88,8 +92,6 @@ export const App = () => {
 			</main>
 		);
 	}
-
-	const { executionErrors } = view.viewProps;
 
 	if (executionErrors.length === 0) {
 		return (
@@ -105,7 +107,7 @@ export const App = () => {
 
 	return (
 		<main>
-			<VSCodeDataGrid>
+			<VSCodeDataGrid gridTemplateColumns="10% 45% 45%">
 				{header}
 				{rows}
 			</VSCodeDataGrid>

--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -1,13 +1,58 @@
 import { useEffect, useState } from 'react';
 import styles from './style.module.css';
-
+import {
+	VSCodeDataGrid,
+	VSCodeDataGridRow,
+	VSCodeDataGridCell,
+} from '@vscode/webview-ui-toolkit/react';
 import type {
 	View,
 	WebviewMessage,
 } from '../../../src/components/webview/webviewEvents';
 import { vscode } from '../shared/utilities/vscode';
+import { ExecutionError } from '../../../src/errors/types';
 
 type ErrorView = Extract<View, { viewId: 'errors' }>;
+
+const header = (
+	<VSCodeDataGridRow row-type="header">
+		<VSCodeDataGridCell cell-type="columnheader" grid-column="1">
+			Kind
+		</VSCodeDataGridCell>
+		<VSCodeDataGridCell cell-type="columnheader" grid-column="2">
+			Message
+		</VSCodeDataGridCell>
+		<VSCodeDataGridCell cell-type="columnheader" grid-column="3">
+			File Path
+		</VSCodeDataGridCell>
+	</VSCodeDataGridRow>
+);
+
+const buildExecutionErrorRow = (
+	executionError: ExecutionError,
+	index: number,
+) => {
+	const kind =
+		typeof executionError !== 'string'
+			? executionError.kind ?? 'errorRunningCodemod'
+			: 'errorRunningCodemod';
+
+	const message =
+		typeof executionError !== 'string'
+			? executionError.message
+			: executionError;
+
+	const filePath =
+		typeof executionError !== 'string' ? executionError.filePath ?? '' : '';
+
+	return (
+		<VSCodeDataGridRow key={index}>
+			<VSCodeDataGridCell grid-column="1">{kind}</VSCodeDataGridCell>
+			<VSCodeDataGridCell grid-column="2">{message}</VSCodeDataGridCell>
+			<VSCodeDataGridCell grid-column="3">{filePath}</VSCodeDataGridCell>
+		</VSCodeDataGridRow>
+	);
+};
 
 export const App = () => {
 	const [view, setView] = useState<ErrorView | null>(null);
@@ -31,13 +76,36 @@ export const App = () => {
 		};
 	}, []);
 
-	if (!view || view.viewProps === null) {
+	if (!view) {
 		return (
-			<p className={styles.welcomeMessage}>
-				Choose a Codemod from Codemod Runs to see its errors.
-			</p>
+			<main>
+				<p className={styles.welcomeMessage}>
+					Choose a codemod run from Codemod Runs to see its errors.
+				</p>
+			</main>
 		);
 	}
 
-	return <main></main>;
+	const { executionErrors } = view.viewProps;
+
+	if (executionErrors.length === 0) {
+		return (
+			<main>
+				<p className={styles.welcomeMessage}>
+					No execution errors found for the selected codemon run.
+				</p>
+			</main>
+		);
+	}
+
+	const rows = executionErrors.map(buildExecutionErrorRow);
+
+	return (
+		<main>
+			<VSCodeDataGrid>
+				{header}
+				{rows}
+			</VSCodeDataGrid>
+		</main>
+	);
 };

--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -57,9 +57,17 @@ const buildExecutionErrorRow = (
 	);
 };
 
+declare global {
+	interface Window {
+		INITIAL_STATE: {
+			viewProps: ViewProps;
+		};
+	}
+}
+
 export const App = () => {
 	const [viewProps, setViewProps] = useState<ViewProps>(
-		(window as any).INITIAL_STATE.viewProps, // TODO fix types
+		window.INITIAL_STATE.viewProps,
 	);
 
 	useEffect(() => {

--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -105,7 +105,7 @@ export const App = () => {
 		return (
 			<main>
 				<p className={styles.welcomeMessage}>
-					No execution errors found for the selected codemon run.
+					No execution errors found for the selected codemod run.
 				</p>
 			</main>
 		);

--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -37,6 +37,9 @@ const buildExecutionErrorRow = (
 			? executionError.kind ?? 'errorRunningCodemod'
 			: 'errorRunningCodemod';
 
+	const humanKind =
+		kind === 'errorRunningCodemod' ? 'Execution Error' : 'Invalid Codemod';
+
 	const message =
 		typeof executionError !== 'string'
 			? executionError.message
@@ -47,7 +50,7 @@ const buildExecutionErrorRow = (
 
 	return (
 		<VSCodeDataGridRow key={index}>
-			<VSCodeDataGridCell grid-column="1">{kind}</VSCodeDataGridCell>
+			<VSCodeDataGridCell grid-column="1">{humanKind}</VSCodeDataGridCell>
 			<VSCodeDataGridCell grid-column="2">{message}</VSCodeDataGridCell>
 			<VSCodeDataGridCell grid-column="3">{filePath}</VSCodeDataGridCell>
 		</VSCodeDataGridRow>

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -634,6 +634,7 @@ export class EngineService {
 					fileCount: this.#execution.totalFileCount,
 					jobs: this.#execution.jobs,
 					case: this.#execution.case,
+					executionErrors,
 				});
 
 				if (

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -28,8 +28,6 @@ export const Messages = {
 	noAffectedFiles:
 		'The codemod has run successfully but didn’t do anything' as const,
 	noImportedMod: 'No imported codemod was found' as const,
-	errorRunningCodemod: 'An error occurred while running the codemod' as const,
-	codemodUnrecognized: 'The codemod is invalid / unsupported' as const,
 };
 
 const TERMINATE_IDLE_PROCESS_TIMEOUT = 15 * 1000;

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -643,23 +643,6 @@ export class EngineService {
 				) {
 					window.showWarningMessage(Messages.noAffectedFiles);
 				}
-
-				executionErrors.forEach((executionError) => {
-					if (typeof executionError === 'string') {
-						window.showErrorMessage(`Error: ${executionError}`);
-					} else {
-						const kind =
-							executionError.kind ?? 'errorRunningCodemod';
-						const kindTitle =
-							kind === 'unrecognizedCodemod'
-								? Messages.codemodUnrecognized
-								: Messages.errorRunningCodemod;
-
-						window.showErrorMessage(
-							`${kindTitle}. Error: ${executionError.message}`,
-						);
-					}
-				});
 			}
 
 			this.#execution = null;

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -3,6 +3,7 @@ import type { CaseHash, CaseWithJobHashes } from '../cases/types';
 import type { Job, JobHash } from '../jobs/types';
 import type { Configuration } from '../configuration';
 import { CodemodHash } from '../packageJsonAnalyzer/types';
+import { ExecutionError } from '../errors/types';
 
 export const enum MessageKind {
 	/** the elements are tree entries */
@@ -174,6 +175,7 @@ export type Message =
 			fileCount: number;
 			jobs: Job[];
 			case: CaseWithJobHashes;
+			executionErrors: ReadonlyArray<ExecutionError>;
 	  }>
 	| Readonly<{
 			kind: MessageKind.extensionActivated;

--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -93,12 +93,12 @@ export class CampaignManagerProvider implements WebviewViewProvider {
 	}
 
 	private __selectCase(hash: CaseHash) {
-		// where does that come from?
 		const node = this.__treeMap.get(hash) ?? null;
 
 		if (node === null) {
 			return;
 		}
+
 		this.__postMessage({
 			kind: 'webview.campaignManager.selectCase',
 			node,

--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -93,6 +93,7 @@ export class CampaignManagerProvider implements WebviewViewProvider {
 	}
 
 	private __selectCase(hash: CaseHash) {
+		// where does that come from?
 		const node = this.__treeMap.get(hash) ?? null;
 
 		if (node === null) {

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -63,7 +63,6 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 	__engineBootstrapped = false;
 	__codemodTree: CodemodTree = E.right(O.none);
 	__autocompleteItems: string[] = [];
-	__workspaceState: WorkspaceState;
 	// map between hash and the Tree Node
 	__treeMap = new Map<CodemodHash, CodemodTreeNode>();
 
@@ -74,12 +73,10 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 		private readonly __messageBus: MessageBus,
 		public readonly __rootPath: string | null,
 		public readonly __codemodService: CodemodService,
+		private readonly __workspaceState: WorkspaceState,
 	) {
 		this.__extensionPath = context.extensionUri;
-		this.__workspaceState = new WorkspaceState(
-			context.workspaceState,
-			__rootPath ?? '/',
-		);
+
 		this.__webviewResolver = new WebviewResolver(this.__extensionPath);
 
 		this.__messageBus.subscribe(MessageKind.engineBootstrapped, () => {

--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -25,6 +25,12 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 				this.setView();
 			},
 		);
+
+		messageBus.subscribe(MessageKind.clearState, () => {
+			__workspaceState.setSelectedCaseHash(null);
+
+			this.setView();
+		});
 	}
 
 	public resolveWebviewView(webviewView: WebviewView): void | Thenable<void> {

--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -1,18 +1,68 @@
 import { ExtensionContext, WebviewView, WebviewViewProvider } from 'vscode';
+import { WorkspaceState } from '../../persistedState/workspaceState';
+import { MessageBus, MessageKind } from '../messageBus';
+import { View, WebviewMessage } from './webviewEvents';
 import { WebviewResolver } from './WebviewResolver';
+
+type ViewProps = Extract<View, { viewId: 'errors' }>['viewProps'];
 
 export class ErrorWebviewProvider implements WebviewViewProvider {
 	private readonly __webviewResolver: WebviewResolver;
+	private __webviewView: WebviewView | null = null;
 
-	public constructor(context: ExtensionContext) {
+	public constructor(
+		context: ExtensionContext,
+		messageBus: MessageBus,
+		private readonly __workspaceState: WorkspaceState,
+	) {
 		this.__webviewResolver = new WebviewResolver(context.extensionUri);
+
+		messageBus.subscribe(
+			MessageKind.codemodSetExecuted,
+			({ case: kase, executionErrors }) => {
+				__workspaceState.setExecutionErrors(kase.hash, executionErrors);
+			},
+		);
 	}
 
-	resolveWebviewView(webviewView: WebviewView): void | Thenable<void> {
+	public resolveWebviewView(webviewView: WebviewView): void | Thenable<void> {
 		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'errors',
 			JSON.stringify({}),
 		);
+	}
+
+	public setView() {
+		const viewProps = this.__buildViewProps();
+
+		this.__postMessage({
+			kind: 'webview.global.setView',
+			value: {
+				viewId: 'errors',
+				viewProps,
+			},
+		});
+	}
+
+	private __buildViewProps(): ViewProps {
+		const cashHash = this.__workspaceState.getSelectedCaseHash();
+
+		if (cashHash === null) {
+			return {
+				executionErrors: [],
+			};
+		}
+
+		const executionErrors =
+			this.__workspaceState.getExecutionErrors(cashHash);
+
+		return {
+			executionErrors,
+		};
+	}
+
+	private __postMessage(message: WebviewMessage) {
+		this.__webviewView?.webview.postMessage(message);
 	}
 }

--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -36,11 +36,17 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 	public resolveWebviewView(webviewView: WebviewView): void | Thenable<void> {
 		this.__webviewView = webviewView;
 
+		const viewProps = this.__buildViewProps();
+
 		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'errors',
-			JSON.stringify({}),
+			JSON.stringify({
+				viewProps,
+			}),
 		);
+
+		this.setView();
 	}
 
 	public showView() {
@@ -60,14 +66,15 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 	}
 
 	private __buildViewProps(): ViewProps {
-		const cashHash = this.__workspaceState.getSelectedCaseHash();
+		const caseHash = this.__workspaceState.getSelectedCaseHash();
 
 		const executionErrors =
-			cashHash !== null
-				? this.__workspaceState.getExecutionErrors(cashHash)
+			caseHash !== null
+				? this.__workspaceState.getExecutionErrors(caseHash)
 				: [];
 
 		return {
+			caseHash,
 			executionErrors,
 		};
 	}

--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -21,11 +21,15 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 			MessageKind.codemodSetExecuted,
 			({ case: kase, executionErrors }) => {
 				__workspaceState.setExecutionErrors(kase.hash, executionErrors);
+
+				this.setView();
 			},
 		);
 	}
 
 	public resolveWebviewView(webviewView: WebviewView): void | Thenable<void> {
+		this.__webviewView = webviewView;
+
 		this.__webviewResolver.resolveWebview(
 			webviewView.webview,
 			'errors',
@@ -48,14 +52,10 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 	private __buildViewProps(): ViewProps {
 		const cashHash = this.__workspaceState.getSelectedCaseHash();
 
-		if (cashHash === null) {
-			return {
-				executionErrors: [],
-			};
-		}
-
 		const executionErrors =
-			this.__workspaceState.getExecutionErrors(cashHash);
+			cashHash !== null
+				? this.__workspaceState.getExecutionErrors(cashHash)
+				: [];
 
 		return {
 			executionErrors,

--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -37,6 +37,10 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 		);
 	}
 
+	public showView() {
+		this.__webviewView?.show();
+	}
+
 	public setView() {
 		const viewProps = this.__buildViewProps();
 

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -6,7 +6,7 @@ import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import { CodemodHash } from '../../packageJsonAnalyzer/types';
 import { CaseHash } from '../../cases/types';
-import { SyntheticError } from '../../errors/types';
+import { ExecutionError, SyntheticError } from '../../errors/types';
 import { ExecutionPath } from '../../persistedState/workspaceState';
 
 export { JobHash };
@@ -339,5 +339,7 @@ export type View =
 	  }>
 	| Readonly<{
 			viewId: 'errors';
-			viewProps: null;
+			viewProps: Readonly<{
+				executionErrors: ReadonlyArray<ExecutionError>;
+			}>;
 	  }>;

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -340,6 +340,7 @@ export type View =
 	| Readonly<{
 			viewId: 'errors';
 			viewProps: Readonly<{
+				caseHash: CaseHash | null;
 				executionErrors: ReadonlyArray<ExecutionError>;
 			}>;
 	  }>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import { TextDocumentContentProvider } from './components/webview/VirtualDocumen
 import { applyChangesCoded } from './components/sourceControl/codecs';
 import prettyReporter from 'io-ts-reporters';
 import { ErrorWebviewProvider } from './components/webview/ErrorWebviewProvider';
+import { WorkspaceState } from './persistedState/workspaceState';
 
 const CODEMOD_METADATA_SCHEME = 'codemod';
 
@@ -124,11 +125,17 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const codemodService = new CodemodService(rootPath, engineService);
 
+	const workspaceState = new WorkspaceState(
+		context.workspaceState,
+		rootPath ?? '/',
+	);
+
 	const codemodListWebviewProvider = new CodemodListPanelProvider(
 		context,
 		messageBus,
 		rootPath,
 		codemodService,
+		workspaceState,
 	);
 
 	context.subscriptions.push(
@@ -963,7 +970,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
 			'intuitaErrorViewId',
-			new ErrorWebviewProvider(context),
+			new ErrorWebviewProvider(context, messageBus, workspaceState),
 		),
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -505,7 +505,10 @@ export async function activate(context: vscode.ExtensionContext) {
 				fileExplorerProvider.showView();
 				fileExplorerProvider.updateExplorerView(caseHash);
 
-				
+				vscode.commands.executeCommand(
+					'workbench.view.extension.intuitaErrorViewId',
+				);
+				errorWebviewProvider.showView();
 				errorWebviewProvider.setView();
 			},
 		),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -306,6 +306,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		new UserHooksService(messageBus, { getConfiguration }, rootPath);
 	}
 
+	const errorWebviewProvider = new ErrorWebviewProvider(
+		context,
+		messageBus,
+		workspaceState,
+	);
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'intuita.focusView',
@@ -493,9 +499,13 @@ export async function activate(context: vscode.ExtensionContext) {
 				if (caseHash === null) {
 					return;
 				}
+				workspaceState.setSelectedCaseHash(caseHash);
+				
 				fileExplorerProvider.setCaseHash(caseHash);
 				fileExplorerProvider.showView();
 				fileExplorerProvider.updateExplorerView(caseHash);
+
+				errorWebviewProvider.setView();
 			},
 		),
 	);
@@ -970,7 +980,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(
 			'intuitaErrorViewId',
-			new ErrorWebviewProvider(context, messageBus, workspaceState),
+			errorWebviewProvider,
 		),
 	);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -506,9 +506,6 @@ export async function activate(context: vscode.ExtensionContext) {
 				fileExplorerProvider.showView();
 				fileExplorerProvider.updateExplorerView(caseHash);
 
-				vscode.commands.executeCommand(
-					'workbench.view.extension.intuitaErrorViewId',
-				);
 				errorWebviewProvider.showView();
 				errorWebviewProvider.setView();
 			},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,11 +500,12 @@ export async function activate(context: vscode.ExtensionContext) {
 					return;
 				}
 				workspaceState.setSelectedCaseHash(caseHash);
-				
+
 				fileExplorerProvider.setCaseHash(caseHash);
 				fileExplorerProvider.showView();
 				fileExplorerProvider.updateExplorerView(caseHash);
 
+				
 				errorWebviewProvider.setView();
 			},
 		),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,6 +128,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	const workspaceState = new WorkspaceState(
 		context.workspaceState,
 		rootPath ?? '/',
+		messageBus,
 	);
 
 	const codemodListWebviewProvider = new CodemodListPanelProvider(

--- a/src/persistedState/workspaceState.ts
+++ b/src/persistedState/workspaceState.ts
@@ -22,6 +22,7 @@ type WorkspaceStateKeyEnvelope = Readonly<
 	| 'openedCodemodHashDigests'
 	| 'focusedCodemodHashDigest'
 	| 'publicCodemodsExpanded'
+	| 'selectedCaseHash'
 	| {
 			kind: 'executionPath';
 			codemodHash: string;
@@ -298,5 +299,29 @@ export class WorkspaceState {
 		});
 
 		this.__memento.update(hashDigest, JSON.stringify(executionErrors));
+	}
+
+	public getSelectedCaseHash(): CaseHash | null {
+		const hashDigest = buildWorkspaceStateKeyHash('selectedCaseHash');
+
+		const value = ensureIsString(this.__memento.get(hashDigest));
+
+		if (value === null) {
+			return null;
+		}
+
+		return value as CaseHash;
+	}
+
+	public setSelectedCaseHash(): CaseHash | null {
+		const hashDigest = buildWorkspaceStateKeyHash('selectedCaseHash');
+
+		const value = ensureIsString(this.__memento.get(hashDigest));
+
+		if (value === null) {
+			return null;
+		}
+
+		return value as CaseHash;
 	}
 }

--- a/src/persistedState/workspaceState.ts
+++ b/src/persistedState/workspaceState.ts
@@ -46,9 +46,13 @@ const buildWorkspaceStateKeyHash = (
 		) as WorkspaceStateKeyHash;
 	}
 
-	return buildHash(
-		[envelope.kind, envelope.caseHash].join(','),
-	) as WorkspaceStateKeyHash;
+	if (envelope.kind === 'executionErrors') {
+		return buildHash(
+			[envelope.kind, envelope.caseHash].join(','),
+		) as WorkspaceStateKeyHash;
+	}
+
+	throw new Error('Unsupported type of the envelope');
 };
 
 const ensureIsString = (value: unknown): string | null => {
@@ -316,6 +320,6 @@ export class WorkspaceState {
 	public setSelectedCaseHash(caseHash: CaseHash): void {
 		const hashDigest = buildWorkspaceStateKeyHash('selectedCaseHash');
 
-		this.__memento.update(hashDigest, JSON.stringify(caseHash));
+		this.__memento.update(hashDigest, caseHash);
 	}
 }

--- a/src/persistedState/workspaceState.ts
+++ b/src/persistedState/workspaceState.ts
@@ -313,15 +313,9 @@ export class WorkspaceState {
 		return value as CaseHash;
 	}
 
-	public setSelectedCaseHash(): CaseHash | null {
+	public setSelectedCaseHash(caseHash: CaseHash): void {
 		const hashDigest = buildWorkspaceStateKeyHash('selectedCaseHash');
 
-		const value = ensureIsString(this.__memento.get(hashDigest));
-
-		if (value === null) {
-			return null;
-		}
-
-		return value as CaseHash;
+		this.__memento.update(hashDigest, JSON.stringify(caseHash));
 	}
 }


### PR DESCRIPTION
https://app.claap.io/intuita/error-panel-c-BT2DRbCjzO-KMBj209_uBAw

Changes:
1. the panel data is sourced from the workspace state at all times
2. the panel shows data during the panel recreation due to 1)
3. the panel is scrollable
4. the panel header is sticky

The discrepancy between the Campaign View (codemod runs) selection and the panel will be tackled in a subsequent PR.