### PR TITLE
Preserve focus on discovery on single click and open doc on doublie click + popover to explain the double click

### DIFF
--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -68,9 +68,21 @@ const TreeItem = ({
 	const [editingPath, setEditingPath] = useState(false);
 
 	useEffect(() => {
-		if (focused) {
-			ref.current?.scrollIntoView(false);
+		if (!focused) {
+			return;
 		}
+
+		const timeout = setTimeout(() => {
+			ref.current?.scrollIntoView({
+				behavior: 'smooth',
+				block: 'center',
+				inline: 'center',
+			});
+		}, 500);
+
+		return () => {
+			clearTimeout(timeout);
+		};
 	}, [focused]);
 
 	const handleEnterKeyDown = () => {

--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -78,7 +78,7 @@ const TreeItem = ({
 			return;
 		}
 
-		onClick();
+		onDoubleClick();
 	};
 
 	useKey('Enter', handleEnterKeyDown);

--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -24,6 +24,7 @@ type Props = {
 	hasChildren: boolean;
 	kind: CodemodTreeNode['kind'];
 	onClick(): void;
+	onDoubleClick(): void;
 	depth: number;
 	disabled: boolean;
 	rootPath: string;
@@ -55,6 +56,7 @@ const TreeItem = ({
 	actionButtons,
 	hasChildren,
 	onClick,
+	onDoubleClick,
 	depth,
 	executionPath,
 	autocompleteItems,
@@ -146,9 +148,8 @@ const TreeItem = ({
 			id={id}
 			ref={ref}
 			className={cn(styles.root, focused && styles.focused)}
-			onClick={() => {
-				onClick();
-			}}
+			onClick={onClick}
+			onDoubleClick={onDoubleClick}
 		>
 			<div
 				style={{
@@ -189,7 +190,22 @@ const TreeItem = ({
 			)}
 			<div className="flex w-full flex-col">
 				<span className={styles.label}>
-					{!editingPath && <span>{label}</span>}
+					<Popover
+						trigger={
+							<span
+								style={{
+									...(editingPath && {
+										display: 'none',
+									}),
+									userSelect: 'none',
+								}}
+							>
+								{label}
+							</span>
+						}
+						popoverText="Double-click to open the documentation."
+						disabled={editingPath}
+					/>
 					<span
 						className={styles.directorySelector}
 						style={{

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -96,6 +96,17 @@ const getIcon = (iconName: string | null, open: boolean): ReactNode => {
 };
 
 const handleDoubleClick = (node: CodemodTreeNode) => {
+	if (!node.doubleClickCommand) {
+		return;
+	}
+
+	vscode.postMessage({
+		kind: 'webview.command',
+		value: node.doubleClickCommand,
+	});
+};
+
+const handleClick = (node: CodemodTreeNode) => {
 	if (!node.command) {
 		return;
 	}
@@ -385,6 +396,8 @@ const TreeView = ({
 				focused={node.id === state.focusedId}
 				autocompleteItems={autocompleteItems}
 				onClick={() => {
+					handleClick(node);
+
 					dispatch({
 						kind: 'flip',
 						id: node.id,

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -385,12 +385,13 @@ const TreeView = ({
 				focused={node.id === state.focusedId}
 				autocompleteItems={autocompleteItems}
 				onClick={() => {
-					handleClick(node);
-
 					dispatch({
 						kind: 'flip',
 						id: node.id,
 					});
+				}}
+				onDoubleClick={() => {
+					handleClick(node);
 				}}
 				actionButtons={getActionButtons()}
 				collapse={() => {

--- a/intuita-webview/src/codemodList/TreeView/index.tsx
+++ b/intuita-webview/src/codemodList/TreeView/index.tsx
@@ -95,7 +95,7 @@ const getIcon = (iconName: string | null, open: boolean): ReactNode => {
 	return <BlueLightBulbIcon />;
 };
 
-const handleClick = (node: CodemodTreeNode) => {
+const handleDoubleClick = (node: CodemodTreeNode) => {
 	if (!node.command) {
 		return;
 	}
@@ -391,7 +391,7 @@ const TreeView = ({
 					});
 				}}
 				onDoubleClick={() => {
-					handleClick(node);
+					handleDoubleClick(node);
 				}}
 				actionButtons={getActionButtons()}
 				collapse={() => {

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -434,7 +434,7 @@ export class CodemodListPanelProvider implements WebviewViewProvider {
 				modKind: repomodHashes.includes(hash)
 					? 'repomod'
 					: 'executeCodemod',
-				command: {
+				doubleClickCommand: {
 					title: 'Show codemod metadata',
 					command: 'intuita.showCodemodMetadata',
 					arguments: [name],

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -60,7 +60,8 @@ export type CodemodTreeNode = {
 	description?: string;
 	parentId: CodemodHash | null;
 	iconName?: string;
-	command?:
+	command?: Command;
+	doubleClickCommand?:
 		| Command & {
 				command: 'intuita.showCodemodMetadata';
 				arguments: [string];


### PR DESCRIPTION
#### Claap: https://app.claap.io/intuita/preserve-focus-on-codemod-item-when-description-is-opened-c-BT2DRbCjzO-V4c3zqaP6EUU

#### Linear: https://linear.app/intuita/issue/INT-1164/preserve-focus-on-codemod-item-when-description-is-opened