### PR TITLE
INT-1190 show the error panel in the store subscriber

### DIFF
--- a/src/components/webview/ErrorWebviewProvider.ts
+++ b/src/components/webview/ErrorWebviewProvider.ts
@@ -36,12 +36,6 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 						errors: executionErrors,
 					}),
 				);
-
-				if (executionErrors.length !== 0) {
-					this.showView();
-
-					await commands.executeCommand('intuitaErrorViewId.focus');
-				}
 			},
 		);
 
@@ -54,7 +48,7 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 
 		let prevProps = this.__buildViewProps();
 
-		this.__store.subscribe(() => {
+		this.__store.subscribe(async () => {
 			const nextProps = this.__buildViewProps();
 
 			if (areEqual(prevProps, nextProps)) {
@@ -70,6 +64,12 @@ export class ErrorWebviewProvider implements WebviewViewProvider {
 					viewProps: nextProps,
 				},
 			});
+
+			if (prevProps.executionErrors.length !== 0) {
+				this.showView();
+
+				await commands.executeCommand('intuitaErrorViewId.focus');
+			}
 		});
 	}
 


### PR DESCRIPTION
If we show the panel without waiting for the changes to be input in the store, the following might happen:

1. the panel is shown (with no errors to show)
2. the store updates with the new errors
3. the message handler in the view is not connected yet, which means the new errors are not updated in the view