### PR TITLE
Fix wrong arrow-up behaviour when file and folder are siblings

### DIFF
--- a/intuita-webview/src/fileExplorer/Tree/index.tsx
+++ b/intuita-webview/src/fileExplorer/Tree/index.tsx
@@ -140,7 +140,6 @@ const Tree = ({
 
 		if (
 			key === 'ArrowUp' &&
-			node.kind === 'folderElement' &&
 			prevNodeAtCurrentDepth !== null &&
 			prevNodeAtCurrentDepth.parentId === node.parentId
 		) {


### PR DESCRIPTION
#### Claap: https://app.claap.io/intuita/fix-wrong-arrow-up-behaviour-when-file-and-folder-are-siblings-c-BT2DRbCjzO-26Z6NdpWs7jv
#### Linear: https://linear.app/intuita/issue/INT-1204/fix-wrong-arrow-up-behaviour-when-file-and-folder-are-siblings