### PR TITLE
INT-1206 refactor selectExplorerTree and the IntuitaTreeView

### DIFF
--- a/intuita-webview/src/intuitaTreeView.tsx
+++ b/intuita-webview/src/intuitaTreeView.tsx
@@ -1,76 +1,130 @@
-import TreeView, { INode, INodeRendererProps } from 'react-accessible-treeview';
+import { useCallback, useRef } from 'react';
+import { useKey } from './jobDiffView/hooks/useKey';
 
 type TreeNode<HD extends string> = Readonly<{
 	hashDigest: HD;
 	label: string;
 }>;
 
-export type TreeViewProps<HD extends string> = Readonly<{
-	rootNodeHashDigest: HD;
-	nodes: Record<HD, TreeNode<HD>>;
-	children: Record<HD, ReadonlyArray<HD>>;
-	parents: Record<HD, HD>;
-	selectedNodeHashDigest: HD | null;
-	expandedNodeHashDigests: ReadonlyArray<HD>;
-	nodeRenderer: (props: INodeRendererProps) => React.ReactNode;
-	onExpand: (hashDigest: HD) => void;
-	onSelect: (hashDigest: HD) => void;
+export type NodeDatum<HD extends string, TN extends TreeNode<HD>> = Readonly<{
+	node: TN;
+	depth: number;
+	expanded: boolean;
+	focused: boolean;
+	childCount: number;
 }>;
 
-const buildData = <HD extends string>(
-	props: TreeViewProps<HD>,
-): ReadonlyArray<INode> => {
-	const nodes: INode[] = [];
+export type TreeViewProps<
+	HD extends string,
+	TN extends TreeNode<HD>,
+> = Readonly<{
+	selectedNodeHashDigest: HD | null;
+	expandedNodeHashDigests: ReadonlyArray<HD>;
+	nodeData: ReadonlyArray<NodeDatum<HD, TN>>;
+	nodeRenderer: (
+		props: Readonly<{
+			nodeDatum: NodeDatum<HD, TN>;
+			onFlip: (hashDigest: HD) => void;
+			onFocus: (hashDigest: HD) => void;
+		}>,
+	) => JSX.Element;
+	onFlip: (hashDigest: HD) => void;
+	onFocus: (hashDigest: HD) => void;
+}>;
 
-	const pushNode = (hashDigest: HD) => {
-		const node = props.nodes[hashDigest] ?? null;
+export const IntuitaTreeView = <HD extends string, TN extends TreeNode<HD>>(
+	props: TreeViewProps<HD, TN>,
+) => {
+	const ref = useRef<HTMLDivElement>(null);
 
-		if (node === null) {
+	const arrowUpCallback = useCallback(() => {
+		if (props.selectedNodeHashDigest === null) {
 			return;
 		}
 
-		const children = props.children[hashDigest]?.slice() ?? [];
+		const index = props.nodeData.findIndex(
+			(nodeDatum) =>
+				nodeDatum.node.hashDigest === props.selectedNodeHashDigest,
+		);
 
-		nodes.push({
-			id: node.hashDigest,
-			children,
-			name: node.label,
-			parent: props.parents[node.hashDigest] ?? null,
-		});
-
-		for (const childHashDigest of children) {
-			pushNode(childHashDigest);
+		if (index === -1) {
+			return;
 		}
-	};
 
-	pushNode(props.rootNodeHashDigest);
+		const newIndex = index === 0 ? props.nodeData.length - 1 : index - 1;
 
-	return nodes;
-};
+		const hashDigest = props.nodeData[newIndex]?.node.hashDigest ?? null;
 
-export const IntuitaTreeView = <HD extends string>(
-	props: TreeViewProps<HD>,
-) => {
-	const data = buildData(props).slice();
+		if (hashDigest === null) {
+			return;
+		}
 
-	const expandedIds = props.expandedNodeHashDigests.slice();
+		props.onFocus(hashDigest);
+	}, [props]);
 
-	const selectedIds = props.selectedNodeHashDigest
-		? [props.selectedNodeHashDigest]
-		: [];
+	const arrowDownCallback = useCallback(() => {
+		if (props.selectedNodeHashDigest === null) {
+			return;
+		}
+
+		const index = props.nodeData.findIndex(
+			(nodeDatum) =>
+				nodeDatum.node.hashDigest === props.selectedNodeHashDigest,
+		);
+
+		if (index === -1) {
+			return;
+		}
+
+		const newIndex = index === props.nodeData.length - 1 ? 0 : index + 1;
+
+		const hashDigest = props.nodeData[newIndex]?.node.hashDigest ?? null;
+
+		if (hashDigest === null) {
+			return;
+		}
+
+		props.onFocus(hashDigest);
+	}, [props]);
+
+	const arrowLeftCallback = useCallback(() => {
+		if (
+			props.selectedNodeHashDigest === null ||
+			!props.expandedNodeHashDigests.includes(
+				props.selectedNodeHashDigest,
+			)
+		) {
+			return;
+		}
+
+		props.onFlip(props.selectedNodeHashDigest);
+	}, [props]);
+
+	const arrowRightCallback = useCallback(() => {
+		if (
+			props.selectedNodeHashDigest === null ||
+			props.expandedNodeHashDigests.includes(props.selectedNodeHashDigest)
+		) {
+			return;
+		}
+
+		props.onFlip(props.selectedNodeHashDigest);
+	}, [props]);
+
+	useKey(ref.current, 'ArrowUp', arrowUpCallback);
+	useKey(ref.current, 'ArrowDown', arrowDownCallback);
+	useKey(ref.current, 'ArrowLeft', arrowLeftCallback);
+	useKey(ref.current, 'ArrowRight', arrowRightCallback);
 
 	return (
-		<TreeView
-			data={data}
-			nodeRenderer={props.nodeRenderer}
-			expandedIds={expandedIds}
-			selectedIds={selectedIds}
-			onExpand={({ element }) => {
-				props.onExpand(element.id as HD);
-			}}
-			onSelect={({ element }) => {
-				props.onSelect(element.id as HD);
-			}}
-		/>
+		<div ref={ref}>
+			{props.nodeData.map((nodeDatum) =>
+				props.nodeRenderer({
+					nodeDatum,
+					onFlip: props.onFlip,
+					onFocus: props.onFocus,
+				}),
+			)}
+		</div>
 	);
 };

--- a/src/selectors/selectExplorerTree.ts
+++ b/src/selectors/selectExplorerTree.ts
@@ -1,7 +1,7 @@
 import platformPath from 'path';
 import { Uri } from 'vscode';
 import { CaseHash } from '../cases/types';
-import { caseAdapter, jobAdapter, State } from '../data/slice';
+import { RootState } from '../data';
 import { Job, JobHash, JobKind, PersistedJob } from '../jobs/types';
 import { LeftRightHashSetManager } from '../leftRightHashes/leftRightHashSetManager';
 import { buildHash, isNeitherNullNorUndefined } from '../utilities';
@@ -82,8 +82,8 @@ export type NodeDatum = Readonly<{
 	childCount: number;
 }>;
 
-export const selectExplorerTree = (state: State, rootPath: Uri | null) => {
-	if (rootPath === null) {
+export const selectExplorerTree = (state: RootState, rootPath: Uri | null) => {
+	if (rootPath === null || state.codemodExecutionInProgress) {
 		return null;
 	}
 
@@ -93,8 +93,7 @@ export const selectExplorerTree = (state: State, rootPath: Uri | null) => {
 		return null;
 	}
 
-	const kase =
-		caseAdapter.getSelectors().selectById(state.case, caseHash) ?? null;
+	const kase = state.case.entities[caseHash] ?? null;
 
 	if (kase === null) {
 		return null;
@@ -131,11 +130,7 @@ export const selectExplorerTree = (state: State, rootPath: Uri | null) => {
 	}
 
 	const jobs = Array.from(caseJobManager.getRightHashesByLeftHash(kase.hash))
-		.map((jobHash) => {
-			return (
-				jobAdapter.getSelectors().selectById(state.job, jobHash) ?? null
-			);
-		})
+		.map((jobHash) => state.job.entities[jobHash])
 		.filter(isNeitherNullNorUndefined)
 		.filter((job) => {
 			if (properSearchPhrase === '') {


### PR DESCRIPTION
Changes:
* ensure that the explorer tree is the object with minimal data (that's why we have the node data there, other structures were not necessary)
* use the custom tree view implementation
* ensure keyboards events are respected