### PR TITLE
INT-1206 simplify community provider

### DIFF
--- a/intuita-webview/src/communityView/App.tsx
+++ b/intuita-webview/src/communityView/App.tsx
@@ -1,15 +1,11 @@
 import { VSCodeLink } from '@vscode/webview-ui-toolkit/react';
 import { ReactComponent as SlackIcon } from '../assets/slack.svg';
 import { ReactComponent as YoutubeIcon } from '../assets/youtube.svg';
-import { ReactElement, useEffect, useState } from 'react';
-import { vscode } from '../shared/utilities/vscode';
-import { View, WebviewMessage } from '../shared/types';
+import { ReactElement } from 'react';
 import { ExternalLink } from '../../../src/components/webview/webviewEvents';
 import intuitaLogo from './../assets/intuita_square128.png';
 
 import styles from './style.module.css';
-
-type MainViews = Extract<View, { viewId: 'communityView' }>;
 
 const getIcon = (id: string): ReactElement | null => {
 	const IntuitaIcon = (
@@ -48,35 +44,10 @@ const getIcon = (id: string): ReactElement | null => {
 type Props = { screenWidth: number | null };
 
 function App({ screenWidth: _screenWidth }: Props) {
-	const [view, setView] = useState<MainViews | null>(null);
-
-	useEffect(() => {
-		const handler = (e: MessageEvent<WebviewMessage>) => {
-			const message = e.data;
-			if (message.kind === 'webview.community.setView') {
-				if (message.value.viewId === 'communityView') {
-					setView(message.value);
-				}
-			}
-		};
-
-		window.addEventListener('message', handler);
-
-		vscode.postMessage({ kind: 'webview.community.afterWebviewMounted' });
-
-		return () => {
-			window.removeEventListener('message', handler);
-		};
-	}, []);
-
-	if (!view || !view.viewProps?.externalLinks) {
-		return null;
-	}
-
 	return (
 		<main className="App">
 			<div className={styles.container}>
-				{view.viewProps.externalLinks.map(
+				{window.INITIAL_STATE.communityProps.externalLinks.map(
 					({ text, url, id }: ExternalLink) => {
 						return (
 							<VSCodeLink className={styles.link} href={url}>

--- a/src/components/webview/CommunityProvider.ts
+++ b/src/components/webview/CommunityProvider.ts
@@ -1,11 +1,5 @@
-import { WebviewView, Uri, ExtensionContext, commands } from 'vscode';
-import {
-	ExternalLink,
-	View,
-	WebviewMessage,
-	WebviewResponse,
-} from './webviewEvents';
-import { WebviewResolver } from './WebviewResolver';
+import { WebviewView, Uri, commands } from 'vscode';
+import { ExternalLink, WebviewResponse } from './webviewEvents';
 
 const EXTERNAL_LINKS: ExternalLink[] = [
 	{
@@ -37,11 +31,6 @@ const EXTERNAL_LINKS: ExternalLink[] = [
 
 export class Community {
 	__view: WebviewView | null = null;
-	__webviewResolver: WebviewResolver;
-
-	constructor(context: ExtensionContext) {
-		this.__webviewResolver = new WebviewResolver(context.extensionUri);
-	}
 
 	setWebview(webviewView: WebviewView): void | Thenable<void> {
 		if (!webviewView.webview) {
@@ -59,17 +48,6 @@ export class Community {
 		};
 	}
 
-	public setView(data: View) {
-		this.__postMessage({
-			kind: 'webview.community.setView',
-			value: data,
-		});
-	}
-
-	private __postMessage(message: WebviewMessage) {
-		this.__view?.webview.postMessage(message);
-	}
-
 	private __onDidReceiveMessage = (message: WebviewResponse) => {
 		if (message.kind === 'webview.command') {
 			if (message.value.command === 'openLink') {
@@ -77,17 +55,7 @@ export class Community {
 					'vscode.open',
 					Uri.parse(message.value.arguments?.[0] ?? ''),
 				);
-				return;
 			}
-		}
-
-		if (message.kind === 'webview.community.afterWebviewMounted') {
-			this.setView({
-				viewId: 'communityView',
-				viewProps: {
-					externalLinks: EXTERNAL_LINKS,
-				},
-			});
 		}
 	};
 

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -152,10 +152,6 @@ export type WebviewMessage =
 			value: View;
 	  }>
 	| Readonly<{
-			kind: 'webview.community.setView';
-			value: View;
-	  }>
-	| Readonly<{
 			kind: 'webview.codemodRuns.setView';
 			value: View;
 	  }>
@@ -225,9 +221,6 @@ export type WebviewResponse =
 	  }>
 	| Readonly<{
 			kind: 'webview.global.afterWebviewMounted';
-	  }>
-	| Readonly<{
-			kind: 'webview.community.afterWebviewMounted';
 	  }>
 	| Readonly<{
 			kind: 'webview.codemodList.afterWebviewMounted';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,7 +190,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		store,
 	);
 
-	const community = new Community(context);
+	const community = new Community();
 
 	const mainViewProvider = new MainViewProvider(
 		context,


### PR DESCRIPTION
Changes:
* use only the `INITIAL_STATE` in the Community tab
* remove event handling from the Community tab
* remove `webview.community.setView` and `webview.community.afterWebviewMounted` events