### PR TITLE
INT-1228 remove the visibility state from the (former) views, now tabs

### DIFF
--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -36,6 +36,7 @@ export const getInitialState = (): RootState => {
 		executionErrors: {},
 		caseHashJobHashes: [],
 		codemodRunsView: {
+			collapsed: false,
 			selectedCaseHash: null,
 		},
 		codemodDiscoveryView: {
@@ -44,6 +45,7 @@ export const getInitialState = (): RootState => {
 			collapsedCodemodHashDigests: [],
 		},
 		changeExplorerView: {
+			collapsed: false,
 			focusedFileExplorerNodeId: null,
 			collapsedNodeHashDigests: [],
 			searchPhrase: '',

--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -6,10 +6,7 @@ import {
 
 import { CodemodEntry } from '../codemods/types';
 import { ExecutionError } from '../errors/types';
-import {
-	CollapsibleWebviews,
-	JobHash,
-} from '../components/webview/webviewEvents';
+import { JobHash } from '../components/webview/webviewEvents';
 import { Case, CaseHash } from '../cases/types';
 import { PersistedJob } from '../jobs/types';
 import { RootState, TabKind } from '../persistedState/codecs';
@@ -40,22 +37,16 @@ export const getInitialState = (): RootState => {
 		caseHashJobHashes: [],
 		codemodRunsView: {
 			selectedCaseHash: null,
-			visible: true,
 		},
 		codemodDiscoveryView: {
 			executionPaths: {},
 			focusedCodemodHashDigest: null,
 			collapsedCodemodHashDigests: [],
-			visible: true,
 		},
 		changeExplorerView: {
 			focusedFileExplorerNodeId: null,
 			collapsedNodeHashDigests: [],
-			visible: false,
 			searchPhrase: '',
-		},
-		communityView: {
-			visible: true,
 		},
 		appliedJobHashes: [],
 		codemodExecutionInProgress: false,
@@ -67,16 +58,6 @@ const rootSlice = createSlice({
 	name: SLICE_KEY,
 	initialState: getInitialState(),
 	reducers: {
-		setVisible(
-			state,
-			action: PayloadAction<{
-				visible: boolean;
-				viewName: CollapsibleWebviews;
-			}>,
-		) {
-			const { visible, viewName } = action.payload;
-			state[viewName].visible = visible;
-		},
 		setCases(state, action: PayloadAction<ReadonlyArray<Case>>) {
 			caseAdapter.setAll(state.case, action.payload);
 		},
@@ -141,7 +122,6 @@ const rootSlice = createSlice({
 			state,
 			action: PayloadAction<CodemodNodeHashDigest | null>,
 		) {
-			state.codemodDiscoveryView.visible = true;
 			state.codemodDiscoveryView.focusedCodemodHashDigest =
 				action.payload;
 		},
@@ -149,8 +129,6 @@ const rootSlice = createSlice({
 			state,
 			action: PayloadAction<CodemodNodeHashDigest>,
 		) {
-			state.codemodDiscoveryView.visible = true;
-
 			const set = new Set<CodemodNodeHashDigest>(
 				state.codemodDiscoveryView.collapsedCodemodHashDigests,
 			);
@@ -184,7 +162,6 @@ const rootSlice = createSlice({
 			state,
 			action: PayloadAction<ExplorerNodeHashDigest | null>,
 		) {
-			state.changeExplorerView.visible = true;
 			state.changeExplorerView.focusedFileExplorerNodeId = action.payload;
 		},
 		flipChangeExplorerHashDigests(
@@ -202,9 +179,6 @@ const rootSlice = createSlice({
 			}
 
 			state.changeExplorerView.collapsedNodeHashDigests = Array.from(set);
-		},
-		setChangeExplorerVisible(state, action: PayloadAction<boolean>) {
-			state.changeExplorerView.visible = action.payload;
 		},
 		clearJobs(state) {
 			jobAdapter.removeAll(state.job);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -353,11 +353,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand(
 			'intuita.openChangeExplorer',
 			async (caseHash: CaseHash | null) => {
+				// TODO validate
 				if (caseHash === null) {
 					return;
 				}
 
-				store.dispatch(actions.setChangeExplorerVisible(true));
+				// TODO this command will be removed in the future
 			},
 		),
 	);

--- a/src/persistedState/codecs.ts
+++ b/src/persistedState/codecs.ts
@@ -76,6 +76,7 @@ export const persistedStateCodecNew = buildTypeCodec({
 	),
 	changeExplorerView: withFallback(
 		buildTypeCodec({
+			collapsed: withFallback(t.boolean, false),
 			focusedFileExplorerNodeId: t.union([
 				explorerNodeHashDigestCodec,
 				t.null,
@@ -89,13 +90,16 @@ export const persistedStateCodecNew = buildTypeCodec({
 			focusedFileExplorerNodeId: null,
 			collapsedNodeHashDigests: [],
 			searchPhrase: '',
+			collapsed: false,
 		},
 	),
 	codemodRunsView: withFallback(
 		buildTypeCodec({
+			collapsed: withFallback(t.boolean, false),
 			selectedCaseHash: t.union([t.string, t.null]),
 		}),
 		{
+			collapsed: false,
 			selectedCaseHash: null,
 		},
 	),

--- a/src/persistedState/codecs.ts
+++ b/src/persistedState/codecs.ts
@@ -57,12 +57,8 @@ export const persistedStateCodecNew = buildTypeCodec({
 		t.record(t.string, t.readonlyArray(executionErrorCodec)),
 		{},
 	),
-	communityView: withFallback(buildTypeCodec({ visible: t.boolean }), {
-		visible: true,
-	}),
 	codemodDiscoveryView: withFallback(
 		buildTypeCodec({
-			visible: t.boolean,
 			executionPaths: t.record(t.string, t.string),
 			focusedCodemodHashDigest: t.union([
 				codemodNodeHashDigestCodec,
@@ -73,7 +69,6 @@ export const persistedStateCodecNew = buildTypeCodec({
 			),
 		}),
 		{
-			visible: true,
 			executionPaths: {},
 			focusedCodemodHashDigest: null,
 			collapsedCodemodHashDigests: [],
@@ -88,24 +83,20 @@ export const persistedStateCodecNew = buildTypeCodec({
 			collapsedNodeHashDigests: t.readonlyArray(
 				explorerNodeHashDigestCodec,
 			),
-			visible: t.boolean,
 			searchPhrase: withFallback(t.string, ''),
 		}),
 		{
 			focusedFileExplorerNodeId: null,
 			collapsedNodeHashDigests: [],
-			visible: true,
 			searchPhrase: '',
 		},
 	),
 	codemodRunsView: withFallback(
 		buildTypeCodec({
 			selectedCaseHash: t.union([t.string, t.null]),
-			visible: t.boolean,
 		}),
 		{
 			selectedCaseHash: null,
-			visible: true,
 		},
 	),
 	caseHashJobHashes: withFallback(t.readonlyArray(t.string), []),


### PR DESCRIPTION
Since the adoption of the tabs in the main view, we don't need to track the `visible` property of the tab, because their visibility is managed by the `activeTabId`.

Also, the `visible` property was essentially dead code.