### PR TITLE
INT-1206 remove the usages of ElementHash

### DIFF
--- a/src/cases/types.ts
+++ b/src/cases/types.ts
@@ -6,7 +6,7 @@ interface CaseHashBrand {
 	readonly __CaseHash: unique symbol;
 }
 
-const caseHashCodec = t.brand(
+export const caseHashCodec = t.brand(
 	t.string,
 	(hashDigest): hashDigest is t.Branded<string, CaseHashBrand> =>
 		hashDigest.length > 0,

--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -196,7 +196,7 @@ export class CampaignManager {
 				{
 					title: 'Diff View',
 					command: 'intuita.openCaseDiff',
-					arguments: [element.hash],
+					arguments: [element.hash as unknown as CaseHash],
 				},
 				{
 					title: 'Change Explorer',

--- a/src/components/webview/CodemodListProvider.ts
+++ b/src/components/webview/CodemodListProvider.ts
@@ -20,12 +20,10 @@ import {
 	CodemodElementWithChildren,
 	CodemodHash,
 } from '../../packageJsonAnalyzer/types';
-import { getElementIconBaseName } from '../../utilities';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import * as T from 'fp-ts/These';
 import * as TE from 'fp-ts/TaskEither';
-import { ElementKind } from '../../elements/types';
 import { readdir } from 'node:fs/promises';
 import { join, parse } from 'node:path';
 import type { SyntheticError } from '../../errors/types';
@@ -408,7 +406,7 @@ export class CodemodListPanel {
 				kind,
 				label,
 				description: description,
-				iconName: getElementIconBaseName(ElementKind.CASE, null),
+				iconName: 'case.svg',
 				id: hash,
 				actions: [
 					{

--- a/src/components/webview/DiffWebviewPanel.ts
+++ b/src/components/webview/DiffWebviewPanel.ts
@@ -4,7 +4,6 @@ import { JobDiffViewProps, View, WebviewResponse } from './webviewEvents';
 import { JobHash, JobKind } from '../../jobs/types';
 import { JobManager } from '../jobManager';
 import { isNeitherNullNorUndefined } from '../../utilities';
-import { ElementHash } from '../../elements/types';
 import { CaseManager } from '../../cases/caseManager';
 import { CaseHash } from '../../cases/types';
 import { IntuitaWebviewPanel, Options } from './WebviewPanel';
@@ -27,7 +26,7 @@ Codemod: ${codemodName}
 **Additional context**`;
 };
 export class DiffWebviewPanel extends IntuitaWebviewPanel {
-	private __selectedCaseHash: ElementHash | null = null;
+	private __selectedCaseHash: CaseHash | null = null;
 
 	constructor(
 		options: Options,
@@ -90,7 +89,7 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 		}
 	}
 
-	public async openCase(caseHash: ElementHash): Promise<void> {
+	public async openCase(caseHash: CaseHash): Promise<void> {
 		this.__selectedCaseHash = caseHash;
 		await this.__refreshView();
 	}
@@ -159,19 +158,18 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 	}
 
 	public async getViewDataForCase(
-		caseHash: ElementHash,
+		caseHash: CaseHash,
 	): Promise<null | Readonly<{
 		title: string;
 		data: JobDiffViewProps[];
 		stagedJobs: JobHash[];
 	}>> {
-		const hash = caseHash as unknown as CaseHash;
-		const kase = this.__caseManager.getCase(hash);
+		const kase = this.__caseManager.getCase(caseHash);
 		if (!kase) {
 			return null;
 		}
 		const jobHashes = Array.from(
-			this.__caseManager.getJobHashes([hash] as unknown as CaseHash[]),
+			this.__caseManager.getJobHashes([caseHash]),
 		);
 
 		if (jobHashes.length === 0) {
@@ -259,7 +257,7 @@ export class DiffWebviewPanel extends IntuitaWebviewPanel {
 		});
 
 		this._addHook(MessageKind.focusFile, async ({ caseHash, jobHash }) => {
-			await this.openCase(caseHash as unknown as ElementHash);
+			await this.openCase(caseHash);
 			this.focusFile(jobHash);
 		});
 	}

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -1,6 +1,5 @@
 import { Command } from 'vscode';
 import { JobHash, JobKind } from '../../jobs/types';
-import { ElementHash } from '../../elements/types';
 export type { Command } from 'vscode';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
@@ -92,7 +91,7 @@ export type CaseTreeNode = {
 	commands?: [
 		Command & {
 			command: 'intuita.openCaseDiff';
-			arguments?: ElementHash[];
+			arguments?: CaseHash[];
 		},
 		Command & {
 			command: 'intuita.openChangeExplorer';
@@ -114,7 +113,7 @@ export type TreeNode = {
 	command?:
 		| Command & {
 				command: 'intuita.openCaseDiff';
-				arguments?: ElementHash[];
+				arguments?: CaseHash[];
 		  };
 	actions?: Command[];
 	children: TreeNode[];

--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -104,7 +104,7 @@ const rootSlice = createSlice({
 		/**
 		 * Codemod runs
 		 */
-		setSelectedCaseHash(state, action: PayloadAction<string | null>) {
+		setSelectedCaseHash(state, action: PayloadAction<CaseHash | null>) {
 			state.codemodRunsView.selectedCaseHash = action.payload;
 		},
 		/**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,6 @@ import { EngineService, Messages } from './components/engineService';
 import { BootstrapExecutablesService } from './components/bootstrapExecutablesService';
 import { buildExecutionId } from './telemetry/hashes';
 import { IntuitaTextDocumentContentProvider } from './components/textDocumentContentProvider';
-import { ElementHash } from './elements/types';
 import { FileExplorer } from './components/webview/FileExplorerProvider';
 import { CampaignManager } from './components/webview/CampaignManagerProvider';
 import { DiffWebviewPanel } from './components/webview/DiffWebviewPanel';
@@ -159,7 +158,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'intuita.openCaseDiff',
-			async (caseHash?: ElementHash) => {
+			async (caseHash?: CaseHash) => {
 				if (!caseHash || !rootPath) {
 					return;
 				}

--- a/src/persistedState/codecs.ts
+++ b/src/persistedState/codecs.ts
@@ -4,7 +4,7 @@ import { codemodEntryCodec } from '../codemods/types';
 import { executionErrorCodec } from '../errors/types';
 import { withFallback } from 'io-ts-types';
 import { jobHashCodec, persistedJobCodec } from '../jobs/types';
-import { caseCodec } from '../cases/types';
+import { caseCodec, caseHashCodec } from '../cases/types';
 import { explorerNodeHashDigestCodec } from '../selectors/selectExplorerTree';
 import { codemodNodeHashDigestCodec } from '../selectors/selectCodemodTree';
 
@@ -96,7 +96,7 @@ export const persistedStateCodecNew = buildTypeCodec({
 	codemodRunsView: withFallback(
 		buildTypeCodec({
 			collapsed: withFallback(t.boolean, false),
-			selectedCaseHash: t.union([t.string, t.null]),
+			selectedCaseHash: t.union([caseHashCodec, t.null]),
 		}),
 		{
 			collapsed: false,

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,8 +1,6 @@
 import * as t from 'io-ts';
 import { createHash } from 'crypto';
 import { Uri, Webview } from 'vscode';
-import { Element, ElementKind } from './elements/types';
-import { JobKind } from './jobs/types';
 
 export type IntuitaRange = Readonly<[number, number, number, number]>;
 
@@ -66,30 +64,6 @@ export function getUri(
 ) {
 	return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
 }
-
-export const getElementIconBaseName = (
-	kind: Element['kind'],
-	jobKind: JobKind | null,
-): string => {
-	switch (kind) {
-		case ElementKind.CASE:
-			return 'case.svg';
-		case ElementKind.FILE:
-			return jobKind !== null &&
-				[
-					JobKind.copyFile,
-					JobKind.createFile,
-					JobKind.moveAndRewriteFile,
-					JobKind.moveFile,
-				].includes(jobKind)
-				? 'newFile.svg'
-				: 'file.svg';
-		case ElementKind.JOB:
-			return 'bluelightbulb.svg';
-		default:
-			return 'bluelightbulb.svg';
-	}
-};
 
 export const capitalize = (str: string): string => {
 	if (!str) {


### PR DESCRIPTION
Removes all the removable usages of ElementHash.
In general, the "elements" are going to be removed in the subsequent PR, where I will have refactored the Codemod Runs and use the new tree there.