### PR TITLE
INT-1206 restore opening of the diff panel after clicking on the codemod run

### DIFF
--- a/intuita-webview/src/campaignManager/App.tsx
+++ b/intuita-webview/src/campaignManager/App.tsx
@@ -76,26 +76,6 @@ function App({ screenWidth: _screenWidth }: Props) {
 					kind: 'webview.campaignManager.setSelectedCaseHash',
 					caseHash: hashDigest,
 				});
-
-				// TODO other commands
-				// node.commands?.forEach((command) => {
-				// 	vscode.postMessage({
-				// 		kind: 'webview.command',
-				// 		value: command,
-				// 	});
-				// });
-				// commands: [
-				// 	{
-				// 		title: 'Diff View',
-				// 		command: 'intuita.openCaseDiff',
-				// 		arguments: [element.hash],
-				// 	},
-				// 	{
-				// 		title: 'Change Explorer',
-				// 		command: 'intuita.openChangeExplorer',
-				// 		arguments: [caseHash],
-				// 	},
-				// ],
 			}}
 		/>
 	);

--- a/intuita-webview/src/shared/types.ts
+++ b/intuita-webview/src/shared/types.ts
@@ -3,7 +3,6 @@ export {
 	View,
 	WebviewMessage,
 	JobDiffViewProps,
-	TreeNode,
 	CodemodTreeNode,
 	Command,
 	RunCodemodsCommand,

--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -101,6 +101,11 @@ export class CampaignManager {
 				this.__store.dispatch(
 					actions.setSelectedCaseHash(message.caseHash),
 				);
+
+				commands.executeCommand(
+					'intuita.openCaseDiff',
+					message.caseHash,
+				);
 			}
 		});
 	}

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -82,50 +82,6 @@ export type CodemodTreeNode = {
 
 export type CodemodTree = E.Either<SyntheticError, O.Option<CodemodTreeNode>>;
 
-export type ChangeExplorerTree = O.Option<TreeNode>;
-
-export type CaseTreeNode = {
-	id: CaseHash;
-	kind: 'caseElement';
-	label?: string;
-	iconName: 'case.svg';
-	commands?: [
-		Command & {
-			command: 'intuita.openCaseDiff';
-			arguments?: CaseHash[];
-		},
-		Command & {
-			command: 'intuita.openChangeExplorer';
-			arguments?: CaseHash[];
-		},
-	];
-	actions?: Command[];
-	children: TreeNode[];
-	caseApplied: boolean;
-};
-
-export type TreeNodeId = string & { __TreeNodeId: '__TreeNodeId' };
-
-export type TreeNode = {
-	id: TreeNodeId;
-	kind: string;
-	label?: string;
-	iconName?: string;
-	command?:
-		| Command & {
-				command: 'intuita.openCaseDiff';
-				arguments?: CaseHash[];
-		  };
-	actions?: Command[];
-	children: TreeNode[];
-	depth: number;
-	parentId: TreeNodeId | null;
-};
-
-export type FileTreeNode = TreeNode & {
-	jobHash: JobHash;
-};
-
 export type CollapsibleWebviews =
 	| 'codemodRunsView'
 	| 'codemodDiscoveryView'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -336,20 +336,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
-			'intuita.openChangeExplorer',
-			async (caseHash: CaseHash | null) => {
-				// TODO validate
-				if (caseHash === null) {
-					return;
-				}
-
-				// TODO this command will be removed in the future
-			},
-		),
-	);
-
-	context.subscriptions.push(
-		vscode.commands.registerCommand(
 			'intuita.executeAsCodemod',
 			async (uri: vscode.Uri) => {
 				try {


### PR DESCRIPTION
Changes:
* open the diff panel after clicking (or focusing) on the codemod run
* remove unused structures in `src/components/webview/webviewEvents.ts`
* remove `intuita.openChangeExplorer` (the change explorer is part of the same tab as the codemod runs)