### PR TITLE
INT-1206 improve the reactivity of the keyboard events

### DIFF
--- a/intuita-webview/src/fileExplorer/explorerNodeRenderer.tsx
+++ b/intuita-webview/src/fileExplorer/explorerNodeRenderer.tsx
@@ -76,6 +76,7 @@ export const explorerNodeRenderer =
 
 		return (
 			<TreeItem
+				key={props.nodeDatum.node.hashDigest}
 				hasChildren={hasChildren}
 				id={props.nodeDatum.node.hashDigest}
 				label={props.nodeDatum.node.label}

--- a/intuita-webview/src/jobDiffView/hooks/useKey.ts
+++ b/intuita-webview/src/jobDiffView/hooks/useKey.ts
@@ -28,7 +28,7 @@ export const useKey = (
 	key: KeyboardEvent['key'],
 	callback: () => void,
 ) => {
-	const keyPressCallback = useCallback(
+	const keyDownCallback = useCallback(
 		(event: KeyboardEvent) => {
 			if (event.key === key) {
 				event.preventDefault();
@@ -42,8 +42,10 @@ export const useKey = (
 		if (container === null) {
 			return;
 		}
-		container.addEventListener('keydown', keyPressCallback);
+		container.addEventListener('keydown', keyDownCallback);
 
-		return () => container.removeEventListener('keydown', keyPressCallback);
-	}, [keyPressCallback, container]);
+		return () => {
+			container.removeEventListener('keydown', keyDownCallback);
+		};
+	}, [keyDownCallback, container]);
 };

--- a/intuita-webview/src/shared/TreeItem/index.tsx
+++ b/intuita-webview/src/shared/TreeItem/index.tsx
@@ -1,9 +1,4 @@
-import {
-	CSSProperties,
-	ReactNode,
-	useLayoutEffect,
-	useRef,
-} from 'react';
+import { CSSProperties, ReactNode, useLayoutEffect, useRef } from 'react';
 import styles from './style.module.css';
 import cn from 'classnames';
 

--- a/intuita-webview/src/shared/TreeItem/index.tsx
+++ b/intuita-webview/src/shared/TreeItem/index.tsx
@@ -1,4 +1,9 @@
-import { CSSProperties, ReactNode, useEffect } from 'react';
+import {
+	CSSProperties,
+	ReactNode,
+	useLayoutEffect,
+	useRef,
+} from 'react';
 import styles from './style.module.css';
 import cn from 'classnames';
 
@@ -37,15 +42,18 @@ const TreeItem = ({
 	inlineStyles,
 	onPressChevron,
 }: Props) => {
-	useEffect(() => {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
 		if (focused) {
-			document.getElementById(id)?.focus();
+			ref.current?.focus();
 		}
-	}, [id, focused]);
+	}, [focused]);
 
 	return (
 		<div
-			id={id}
+			key={id}
+			ref={ref}
 			tabIndex={0}
 			className={cn(styles.root, focused && styles.focused)}
 			onClick={onClick}

--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -106,6 +106,8 @@ const rootSlice = createSlice({
 		 */
 		setSelectedCaseHash(state, action: PayloadAction<CaseHash | null>) {
 			state.codemodRunsView.selectedCaseHash = action.payload;
+			state.changeExplorerView.focusedFileExplorerNodeId = null;
+			state.changeExplorerView.collapsedNodeHashDigests = [];
 		},
 		/**
 		 * Codemod list


### PR DESCRIPTION
Changes:
* instead of using `useEffect`, use `useLayoutEffect`
* use `ref` instead of `getElementById`
* when launching `setSelectedCaseHash` action, clean up the selection of `focusedFileExplorerNodeId`