### PR TITLE
INT-1241 the new explorer node codec

### DIFF
--- a/src/persistedState/explorerNodeCodec.ts
+++ b/src/persistedState/explorerNodeCodec.ts
@@ -1,0 +1,46 @@
+import * as t from 'io-ts';
+import { jobHashCodec } from '../jobs/types';
+import { buildTypeCodec } from '../utilities';
+
+interface ExplorerNodeHashDigestBrand {
+	readonly __ExplorerNodeHashDigest: unique symbol;
+}
+
+export const explorerNodeHashDigestCodec = t.brand(
+	t.string,
+	(
+		hashDigest,
+	): hashDigest is t.Branded<string, ExplorerNodeHashDigestBrand> =>
+		hashDigest.length > 0,
+	'__ExplorerNodeHashDigest',
+);
+
+export type ExplorerNodeHashDigest = t.TypeOf<
+	typeof explorerNodeHashDigestCodec
+>;
+
+export const explorerNodeCodec = t.union([
+	buildTypeCodec({
+		hashDigest: explorerNodeHashDigestCodec,
+		kind: t.literal('ROOT'),
+		label: t.string,
+		depth: t.number,
+	}),
+	buildTypeCodec({
+		hashDigest: explorerNodeHashDigestCodec,
+		kind: t.literal('DIRECTORY'),
+		label: t.string,
+		depth: t.number,
+	}),
+	buildTypeCodec({
+		hashDigest: explorerNodeHashDigestCodec,
+		kind: t.literal('FILE'),
+		path: t.string,
+		label: t.string,
+		depth: t.number,
+		jobHash: jobHashCodec,
+		fileAdded: t.boolean,
+	}),
+]);
+
+export type ExplorerNode = t.TypeOf<typeof explorerNodeCodec>;


### PR DESCRIPTION
The new explorer codec, more suitable for the data persisted in the store and streamed down to the selectors and later to the components.