### PR TITLE
INT-1241 Change the change explorer's state to allow for directory selection

### DIFF
--- a/intuita-webview/src/campaignManager/App.tsx
+++ b/intuita-webview/src/campaignManager/App.tsx
@@ -44,14 +44,14 @@ function App() {
 
 	return (
 		<IntuitaTreeView<CaseHash, CodemodRunsTree['nodeData'][0]['node']>
-			selectedNodeHashDigest={viewProps.selectedNodeHashDigest}
+			focusedNodeHashDigest={viewProps.selectedNodeHashDigest}
 			collapsedNodeHashDigests={[]}
 			nodeData={viewProps.nodeData}
 			nodeRenderer={(props) => {
 				return (
 					<TreeItem
 						key={props.nodeDatum.node.hashDigest}
-						hasChildren={props.nodeDatum.childCount !== 0}
+						hasChildren={props.nodeDatum.collapsable}
 						id={props.nodeDatum.node.hashDigest}
 						label={props.nodeDatum.node.label}
 						subLabel=""

--- a/intuita-webview/src/errors/App.tsx
+++ b/intuita-webview/src/errors/App.tsx
@@ -105,19 +105,21 @@ export const App = () => {
 		};
 	}, []);
 
-	const { caseHash, executionErrors } = viewProps;
-
-	if (caseHash === null) {
+	if (viewProps.kind !== 'CASE_SELECTED') {
 		return (
 			<main>
 				<p className={styles.welcomeMessage}>
-					Choose a codemod run from Codemod Runs to see its errors.
+					{viewProps.kind === 'MAIN_WEBVIEW_VIEW_NOT_VISIBLE'
+						? 'Open the left-sided Intuita View Container to see the errors.'
+						: viewProps.kind === 'CODEMOD_RUNS_TAB_NOT_ACTIVE'
+						? 'Open the Codemod Runs tab to see the errors.'
+						: 'Choose a codemod run from Codemod Runs to see its errors.'}
 				</p>
 			</main>
 		);
 	}
 
-	if (executionErrors.length === 0) {
+	if (viewProps.executionErrors.length === 0) {
 		return (
 			<main>
 				<p className={styles.welcomeMessage}>
@@ -127,7 +129,7 @@ export const App = () => {
 		);
 	}
 
-	const rows = executionErrors.map(buildExecutionErrorRow);
+	const rows = viewProps.executionErrors.map(buildExecutionErrorRow);
 
 	return (
 		<main>

--- a/intuita-webview/src/fileExplorer/ActionsHeader/index.tsx
+++ b/intuita-webview/src/fileExplorer/ActionsHeader/index.tsx
@@ -14,11 +14,10 @@ const POPOVER_TEXTS = {
 };
 
 const flipSelectedExplorerNodes = (caseHashDigest: CaseHash) => {
-	// TODO RESTORE
-	// vscode.postMessage({
-	// 	kind: 'webview.global.flipSelectedExplorerNodes',
-	// 	caseHashDigest,
-	// });
+	vscode.postMessage({
+		kind: 'webview.global.flipSelectedExplorerNodes',
+		caseHashDigest,
+	});
 };
 
 const discardChanges = (caseHashDigest: CaseHash) => {
@@ -31,8 +30,7 @@ const discardChanges = (caseHashDigest: CaseHash) => {
 const applySelected = (caseHashDigest: CaseHash) => {
 	vscode.postMessage({
 		kind: 'webview.global.applySelected',
-		jobHashes: [], // TODO remove
-		diffId: caseHashDigest, // TODO to caseHashDigest
+		caseHashDigest,
 	});
 };
 

--- a/intuita-webview/src/intuitaTreeView.tsx
+++ b/intuita-webview/src/intuitaTreeView.tsx
@@ -11,14 +11,14 @@ export type NodeDatum<HD extends string, TN extends TreeNode<HD>> = Readonly<{
 	depth: number;
 	expanded: boolean;
 	focused: boolean;
-	childCount: number;
+	collapsable: boolean;
 }>;
 
 export type TreeViewProps<
 	HD extends string,
 	TN extends TreeNode<HD>,
 > = Readonly<{
-	selectedNodeHashDigest: HD | null;
+	focusedNodeHashDigest: HD | null;
 	collapsedNodeHashDigests: ReadonlyArray<HD>;
 	nodeData: ReadonlyArray<NodeDatum<HD, TN>>;
 	nodeRenderer: (
@@ -38,13 +38,13 @@ export const IntuitaTreeView = <HD extends string, TN extends TreeNode<HD>>(
 	const ref = useRef<HTMLDivElement>(null);
 
 	const arrowUpCallback = useCallback(() => {
-		if (props.selectedNodeHashDigest === null) {
+		if (props.focusedNodeHashDigest === null) {
 			return;
 		}
 
 		const index = props.nodeData.findIndex(
 			(nodeDatum) =>
-				nodeDatum.node.hashDigest === props.selectedNodeHashDigest,
+				nodeDatum.node.hashDigest === props.focusedNodeHashDigest,
 		);
 
 		if (index === -1) {
@@ -63,13 +63,13 @@ export const IntuitaTreeView = <HD extends string, TN extends TreeNode<HD>>(
 	}, [props]);
 
 	const arrowDownCallback = useCallback(() => {
-		if (props.selectedNodeHashDigest === null) {
+		if (props.focusedNodeHashDigest === null) {
 			return;
 		}
 
 		const index = props.nodeData.findIndex(
 			(nodeDatum) =>
-				nodeDatum.node.hashDigest === props.selectedNodeHashDigest,
+				nodeDatum.node.hashDigest === props.focusedNodeHashDigest,
 		);
 
 		if (index === -1) {
@@ -89,28 +89,26 @@ export const IntuitaTreeView = <HD extends string, TN extends TreeNode<HD>>(
 
 	const arrowLeftCallback = useCallback(() => {
 		if (
-			props.selectedNodeHashDigest === null ||
-			props.collapsedNodeHashDigests.includes(
-				props.selectedNodeHashDigest,
-			)
+			props.focusedNodeHashDigest === null ||
+			props.collapsedNodeHashDigests.includes(props.focusedNodeHashDigest)
 		) {
 			return;
 		}
 
-		props.onFlip(props.selectedNodeHashDigest);
+		props.onFlip(props.focusedNodeHashDigest);
 	}, [props]);
 
 	const arrowRightCallback = useCallback(() => {
 		if (
-			props.selectedNodeHashDigest === null ||
+			props.focusedNodeHashDigest === null ||
 			!props.collapsedNodeHashDigests.includes(
-				props.selectedNodeHashDigest,
+				props.focusedNodeHashDigest,
 			)
 		) {
 			return;
 		}
 
-		props.onFlip(props.selectedNodeHashDigest);
+		props.onFlip(props.focusedNodeHashDigest);
 	}, [props]);
 
 	useKey(ref.current, 'ArrowUp', arrowUpCallback);

--- a/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/index.tsx
@@ -8,10 +8,15 @@ import { Diff } from './Diff';
 import { useTheme } from '../../shared/Snippet/useTheme';
 import type { PanelViewProps } from '../../../../src/components/webview/panelViewProps';
 import { vscode } from '../../shared/utilities/vscode';
+import { CaseHash } from '../../../../src/cases/types';
 
-const changeJob = (direction: 'prev' | 'next') => {
+const focusExplorerNodeSibling = (
+	caseHashDigest: CaseHash,
+	direction: 'prev' | 'next',
+) => {
 	vscode.postMessage({
-		kind: 'webview.panel.changeJob',
+		kind: 'webview.global.focusExplorerNodeSibling',
+		caseHashDigest,
 		direction,
 	});
 };
@@ -36,7 +41,9 @@ export const JobDiffViewContainer = (
 				viewType={viewType}
 				jobCount={props.jobCount}
 				jobIndex={props.jobIndex}
-				changeJob={changeJob}
+				changeJob={(direction) =>
+					focusExplorerNodeSibling(props.caseHash, direction)
+				}
 			/>
 			<div className="w-full pb-2-5 h-full" ref={containerRef}>
 				<JobDiffView

--- a/src/cases/caseManager.ts
+++ b/src/cases/caseManager.ts
@@ -31,26 +31,13 @@ export class CaseManager {
 	#onUpsertCasesMessage(
 		message: Message & { kind: MessageKind.upsertCases },
 	) {
-		const newCaseHash = message.casesWithJobHashes[0]?.hash ?? null;
-		if (newCaseHash === null) {
-			return;
-		}
+		const caseHashJobHashes = message.jobs.map(
+			({ hash }) => `${message.kase.hash}${hash}`,
+		);
 
-		// TODO we only upsert one case at the time I think
-		message.casesWithJobHashes.map((caseWithJobHash) => {
-			const caseHashJobHashes = Array.from(caseWithJobHash.jobHashes).map(
-				(jobHash) => {
-					return `${caseWithJobHash.hash}${jobHash}`;
-				},
-			);
-
-			const kase = { ...caseWithJobHash, jobHashes: [] };
-
-			this.__store.dispatch(actions.upsertCases([kase]));
-			this.__store.dispatch(
-				actions.upsertCaseHashJobHashes(caseHashJobHashes),
-			);
-		});
+		this.__store.dispatch(
+			actions.upsertCase([message.kase, caseHashJobHashes]),
+		);
 
 		this.__messageBus.publish({
 			kind: MessageKind.upsertJobs,

--- a/src/cases/types.ts
+++ b/src/cases/types.ts
@@ -1,4 +1,3 @@
-import type { JobHash } from '../jobs/types';
 import { buildTypeCodec } from '../utilities';
 import * as t from 'io-ts';
 
@@ -28,8 +27,3 @@ export const caseCodec = buildTypeCodec({
 });
 
 export type Case = t.TypeOf<typeof caseCodec>;
-
-export type CaseWithJobHashes = Case &
-	Readonly<{
-		jobHashes: ReadonlySet<JobHash>;
-	}>;

--- a/src/components/jobManager.ts
+++ b/src/components/jobManager.ts
@@ -34,11 +34,6 @@ export class JobManager {
 		const persistedJobs = message.jobs.map(mapJobToPersistedJob);
 
 		this.__store.dispatch(actions.upsertJobs(persistedJobs));
-		this.__store.dispatch(
-			actions.upsertAppliedJobHashes(
-				message.jobs.map(({ hash }) => hash),
-			),
-		);
 	}
 
 	private async __onAcceptJobsMessage(
@@ -63,10 +58,6 @@ export class JobManager {
 			kind: MessageKind.jobsAccepted,
 			deletedJobs: new Set(deletedJobs),
 		});
-	}
-
-	public setAppliedJobs(jobHashes: ReadonlyArray<JobHash>): void {
-		this.__store.dispatch(actions.setAppliedJobHashes(jobHashes));
 	}
 
 	public deleteJobs(jobHash: ReadonlyArray<JobHash>) {

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -1,5 +1,5 @@
 import { Disposable, EventEmitter, Uri } from 'vscode';
-import type { CaseHash, CaseWithJobHashes } from '../cases/types';
+import type { Case, CaseHash } from '../cases/types';
 import type { Job, JobHash } from '../jobs/types';
 import { CodemodHash } from '../packageJsonAnalyzer/types';
 import { ExecutionError } from '../errors/types';
@@ -42,6 +42,8 @@ export const enum MessageKind {
 	focusCodemod = 35,
 
 	focusFile = 37,
+
+	mainWebviewViewVisibilityChange = 38,
 }
 
 export type Command =
@@ -67,8 +69,9 @@ export type Command =
 
 export type Message =
 	| Readonly<{
+			// TODO change it later to `upsertCase`
 			kind: MessageKind.upsertCases;
-			casesWithJobHashes: ReadonlyArray<CaseWithJobHashes>;
+			kase: Case;
 			jobs: ReadonlyArray<Job>;
 			executionId: string;
 	  }>
@@ -120,7 +123,7 @@ export type Message =
 			halted: boolean;
 			fileCount: number;
 			jobs: Job[];
-			case: CaseWithJobHashes;
+			case: Case;
 			executionErrors: ReadonlyArray<ExecutionError>;
 	  }>
 	| Readonly<{
@@ -155,9 +158,7 @@ export type Message =
 			codemodHashDigest: CodemodHash;
 	  }>
 	| Readonly<{
-			kind: MessageKind.focusFile;
-			caseHash: CaseHash;
-			jobHash: JobHash;
+			kind: MessageKind.mainWebviewViewVisibilityChange;
 	  }>;
 
 type EmitterMap<K extends MessageKind> = {

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -6,16 +6,14 @@ import { CodemodHash } from '../../packageJsonAnalyzer/types';
 import { CaseHash } from '../../cases/types';
 import { ExecutionError, SyntheticError } from '../../errors/types';
 import { TabKind } from '../../persistedState/codecs';
-import {
-	ExplorerNodeHashDigest,
-	ExplorerTree,
-} from '../../selectors/selectExplorerTree';
+import { ExplorerTree } from '../../selectors/selectExplorerTree';
 import { CodemodRunsTree } from '../../selectors/selectCodemodRunsTree';
 import {
 	CodemodNodeHashDigest,
 	CodemodTree,
 } from '../../selectors/selectCodemodTree';
 import { PanelViewProps } from './panelViewProps';
+import { _ExplorerNodeHashDigest } from '../../persistedState/explorerNodeCodec';
 
 export type ExecutionPath = T.These<SyntheticError, string>;
 
@@ -100,7 +98,24 @@ export type WebviewMessage =
 
 export type WebviewResponse =
 	| Readonly<{
-			kind: 'webview.panel.changeJob';
+			kind: 'webview.global.focusExplorerNode';
+			caseHashDigest: CaseHash;
+			explorerNodeHashDigest: _ExplorerNodeHashDigest;
+	  }>
+	| Readonly<{
+			kind:
+				| 'webview.global.flipSelectedExplorerNode'
+				| 'webview.global.flipCollapsibleExplorerNode';
+			caseHashDigest: CaseHash;
+			explorerNodeHashDigest: _ExplorerNodeHashDigest;
+	  }>
+	| Readonly<{
+			kind: 'webview.global.flipSelectedExplorerNodes';
+			caseHashDigest: CaseHash;
+	  }>
+	| Readonly<{
+			kind: 'webview.global.focusExplorerNodeSibling';
+			caseHashDigest: CaseHash;
 			direction: 'prev' | 'next';
 	  }>
 	| Readonly<{
@@ -119,15 +134,11 @@ export type WebviewResponse =
 	| Omit<RunCodemodsCommand, 'title' | 'shortenedTitle' | 'description'>
 	| Readonly<{
 			kind: 'webview.global.applySelected';
-			jobHashes: ReadonlyArray<JobHash>;
-			diffId: string;
-	  }>
-	| Readonly<{
-			kind: 'webview.global.stageJobs';
-			jobHashes: ReadonlyArray<JobHash>;
+			caseHashDigest: CaseHash;
 	  }>
 	| Readonly<{
 			kind: 'webview.global.setChangeExplorerSearchPhrase';
+			caseHashDigest: CaseHash;
 			searchPhrase: string;
 	  }>
 	| Readonly<{
@@ -135,14 +146,9 @@ export type WebviewResponse =
 			searchPhrase: string;
 	  }>
 	| Readonly<{
-			kind: 'webview.global.selectExplorerNodeHashDigest';
-			selectedExplorerNodeHashDigest: ExplorerNodeHashDigest;
-			caseHash: CaseHash;
-			jobHash: JobHash | null; // TODO probably not jobHash
-	  }>
-	| Readonly<{
-			kind: 'webview.global.flipChangeExplorerNodeIds';
-			hashDigest: ExplorerNodeHashDigest;
+			kind: 'webview.global.flipChangeExplorerNodeHashDigests';
+			caseHashDigest: CaseHash;
+			explorerNodeHashDigest: _ExplorerNodeHashDigest;
 	  }>
 	| Readonly<{ kind: 'webview.global.showInformationMessage'; value: string }>
 	| Readonly<{ kind: 'webview.global.showWarningMessage'; value: string }>
@@ -205,8 +211,16 @@ export type View =
 	  }>
 	| Readonly<{
 			viewId: 'errors';
-			viewProps: Readonly<{
-				caseHash: CaseHash | null;
-				executionErrors: ReadonlyArray<ExecutionError>;
-			}>;
+			viewProps:
+				| Readonly<{
+						kind:
+							| 'MAIN_WEBVIEW_VIEW_NOT_VISIBLE'
+							| 'CODEMOD_RUNS_TAB_NOT_ACTIVE'
+							| 'CASE_NOT_SELECTED';
+				  }>
+				| Readonly<{
+						kind: 'CASE_SELECTED';
+						caseHash: CaseHash;
+						executionErrors: ReadonlyArray<ExecutionError>;
+				  }>;
 	  }>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,6 +121,8 @@ export async function activate(context: vscode.ExtensionContext) {
 	new IntuitaPanelProvider(
 		context.extensionUri,
 		store,
+		mainViewProvider,
+		messageBus,
 		codemodDescriptionProvider,
 		rootPath ?? '',
 	);
@@ -131,6 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		context,
 		messageBus,
 		store,
+		mainViewProvider,
 	);
 
 	// this is only used by the intuita panel's webview

--- a/src/persistedState/codecs.ts
+++ b/src/persistedState/codecs.ts
@@ -3,9 +3,8 @@ import { buildTypeCodec } from '../utilities';
 import { codemodEntryCodec } from '../codemods/types';
 import { executionErrorCodec } from '../errors/types';
 import { withFallback } from 'io-ts-types';
-import { jobHashCodec, persistedJobCodec } from '../jobs/types';
+import { persistedJobCodec } from '../jobs/types';
 import { caseCodec, caseHashCodec } from '../cases/types';
-import { explorerNodeHashDigestCodec } from '../selectors/selectExplorerTree';
 import { codemodNodeHashDigestCodec } from '../selectors/selectCodemodTree';
 import {
 	_explorerNodeCodec,
@@ -83,21 +82,8 @@ export const persistedStateCodecNew = buildTypeCodec({
 	changeExplorerView: withFallback(
 		buildTypeCodec({
 			collapsed: withFallback(t.boolean, false),
-			focusedFileExplorerNodeId: t.union([
-				explorerNodeHashDigestCodec,
-				t.null,
-			]),
-			focusedJobHash: t.union([jobHashCodec, t.null]),
-			collapsedNodeHashDigests: t.readonlyArray(
-				explorerNodeHashDigestCodec,
-			),
-			searchPhrase: withFallback(t.string, ''),
 		}),
 		{
-			focusedFileExplorerNodeId: null,
-			focusedJobHash: null,
-			collapsedNodeHashDigests: [],
-			searchPhrase: '',
 			collapsed: false,
 		},
 	),
@@ -112,7 +98,6 @@ export const persistedStateCodecNew = buildTypeCodec({
 		},
 	),
 	caseHashJobHashes: withFallback(t.readonlyArray(t.string), []),
-	appliedJobHashes: withFallback(t.readonlyArray(jobHashCodec), []),
 	codemodExecutionInProgress: withFallback(t.boolean, false),
 	activeTabId: withFallback(
 		t.union([

--- a/src/selectors/selectCodemodRunsTree.ts
+++ b/src/selectors/selectCodemodRunsTree.ts
@@ -21,7 +21,7 @@ export const selectCodemodRunsTree = (state: RootState) => {
 					depth: 0,
 					expanded: true,
 					focused: kase.hash === selectedCaseHash,
-					childCount: 0,
+					collapsable: false,
 				} as const),
 		);
 

--- a/src/selectors/selectCodemodTree.ts
+++ b/src/selectors/selectCodemodTree.ts
@@ -22,7 +22,7 @@ export type NodeDatum = Readonly<{
 	depth: number;
 	expanded: boolean;
 	focused: boolean;
-	childCount: number;
+	collapsable: boolean;
 }>;
 
 const buildCodemodTitle = (name: string): string => {
@@ -167,7 +167,7 @@ export const selectCodemodTree = (state: RootState, rootPath: string) => {
 				depth,
 				expanded,
 				focused,
-				childCount: childSet.length,
+				collapsable: childSet.length !== 0,
 			});
 		}
 
@@ -184,10 +184,10 @@ export const selectCodemodTree = (state: RootState, rootPath: string) => {
 
 	return {
 		nodeData,
-		selectedNodeHashDigest: state.codemodDiscoveryView
-			.focusedCodemodHashDigest as CodemodNodeHashDigest | null,
-		collapsedNodeHashDigests: state.codemodDiscoveryView
-			.collapsedCodemodHashDigests as CodemodNodeHashDigest[],
+		focusedNodeHashDigest:
+			state.codemodDiscoveryView.focusedCodemodHashDigest,
+		collapsedNodeHashDigests:
+			state.codemodDiscoveryView.collapsedCodemodHashDigests,
 	};
 };
 


### PR DESCRIPTION
https://linear.app/intuita/issue/INT-1241/change-the-change-explorers-state-to-allow-for-directory-selection

Changes:
* `selectedNodeHashDigest` -> `focusedNodeHashDigest` b/c the former means the checkbox selection, not the focus
* `childCount` -> `collapsible` (we don't need precise count)
* `CaseWithJobHashes` got removed, all usages replaced with `Case`
* add `MessageKind.mainWebviewViewVisibilityChange` message
* refactor selectors & actions to match the new structures in the store