### PR TITLE
INT-1304 refactor the CodemodRuns Tab to control collapsing/expanding of panels

### DIFF
--- a/intuita-webview/src/main/App.tsx
+++ b/intuita-webview/src/main/App.tsx
@@ -8,7 +8,7 @@ import {
 
 import { App as CodemodList } from '../codemodList/App';
 import { CommunityTab } from '../communityTab/CommunityTab';
-import CodemodRuns from './CodemodRuns';
+import { CodemodRuns } from './CodemodRuns';
 import { WebviewMessage } from '../shared/types';
 import { vscode } from '../shared/utilities/vscode';
 import { ActiveTabId } from '../../../src/persistedState/codecs';

--- a/intuita-webview/src/main/CodemodRuns.tsx
+++ b/intuita-webview/src/main/CodemodRuns.tsx
@@ -1,158 +1,132 @@
-import { CSSProperties, useEffect, useRef } from 'react';
-
 import {
 	PanelResizeHandle,
-	ImperativePanelHandle,
 	PanelGroupStorage,
+	ImperativePanelHandle,
 } from 'react-resizable-panels';
 
 import { ResizablePanel, PanelGroup } from '../shared/Panel';
-import SectionHeader from '../shared/SectionHeader';
-import { WebviewMessage } from '../shared/types';
+import { SectionHeader } from '../shared/SectionHeader';
 
 import { App as CampaignManager } from '../campaignManager/App';
 import { App as FileExplorer } from '../fileExplorer/App';
 
-import { CollapsibleWebviews } from '../../../src/components/webview/webviewEvents';
 import { MainWebviewViewProps } from '../../../src/selectors/selectMainWebviewViewProps';
 import { vscode } from '../shared/utilities/vscode';
+import { useEffect, useMemo, useRef } from 'react';
 
-type Props = Readonly<{
-	screenWidth: number | null;
-}> &
-	MainWebviewViewProps & { activeTabId: 'codemodRuns' };
-
-const RESIZABLE_PANELS: {
-	id: CollapsibleWebviews;
-	title: string;
-	Component: React.FC<Props>;
-	commands?: any[];
-	inlineStyle?: CSSProperties;
-}[] = [
-	{
-		id: 'codemodRunsView',
-		title: 'Results',
-		commands: [
-			{
-				icon: 'clear-all',
-				title: 'Clear all',
-				command: 'intuita.clearState',
-			},
-		],
-		Component: CampaignManager,
+export const CodemodRuns = (
+	props: MainWebviewViewProps & {
+		activeTabId: 'codemodRuns';
+		screenWidth: number | null;
 	},
-	{
-		id: 'changeExplorerView',
-		title: 'Change Explorer',
-		Component: FileExplorer,
-	},
-];
-
-const CodemodRuns = (props: Props) => {
-	const panelRefs = useRef<Record<string, ImperativePanelHandle>>({});
-
-	const togglePanel = (id: string) => {
-		const ref = panelRefs.current[id];
-
-		if (!ref) {
-			return;
-		}
-		const collapsed = ref.getCollapsed();
-		if (collapsed) {
-			ref.expand();
-		} else {
-			ref.collapse();
-		}
-	};
+) => {
+	const resultsRef = useRef<ImperativePanelHandle | null>(null);
+	const changeExplorerRef = useRef<ImperativePanelHandle | null>(null);
 
 	useEffect(() => {
-		const handler = (e: MessageEvent<WebviewMessage>) => {
-			const message = e.data;
-			if (message.kind === 'webview.main.setCollapsed') {
-				const ref = panelRefs.current[message.viewName];
-				if (!ref) {
-					return;
-				}
-				if (message.collapsed) {
-					ref.collapse();
-				} else {
-					ref.expand();
-				}
-			}
-		};
+		if (props.resultsCollapsed) {
+			resultsRef.current?.collapse();
+		} else {
+			resultsRef.current?.expand();
+		}
 
-		window.addEventListener('message', handler);
+		if (props.changeExplorerCollapsed) {
+			changeExplorerRef.current?.collapse();
+		} else {
+			changeExplorerRef.current?.expand();
+		}
+	}, [props.resultsCollapsed, props.changeExplorerCollapsed]);
 
-		return () => {
-			window.removeEventListener('message', handler);
-		};
-	}, []);
-
-	const storage: PanelGroupStorage = {
-		getItem: () => JSON.stringify(props.panelGroupSettings),
-		setItem: (_, panelGroupSettings: string): void => {
-			vscode.postMessage({
-				kind: 'webview.main.setPanelGroupSettings',
-				panelGroupSettings,
-			});
-		},
-	};
+	const storage = useMemo(
+		(): PanelGroupStorage => ({
+			getItem: () => JSON.stringify(props.panelGroupSettings),
+			setItem: (_, panelGroupSettings: string): void => {
+				vscode.postMessage({
+					kind: 'webview.main.setPanelGroupSettings',
+					panelGroupSettings,
+				});
+			},
+		}),
+		[props.panelGroupSettings],
+	);
 
 	return (
 		<div className="w-full h-full">
 			<PanelGroup
 				direction="vertical"
 				storage={storage}
-				autoSaveId="codemodRuns"
+				autoSaveId="codemodRunsPanelGroup"
 			>
-				{RESIZABLE_PANELS.map(
-					(
+				<SectionHeader
+					title={'Results'}
+					commands={[
 						{
-							id,
-							title,
-							commands = [],
-							Component,
-							inlineStyle = {},
+							icon: 'clear-all',
+							title: 'Clear all',
+							command: 'intuita.clearState',
 						},
-						idx,
-					) => {
-						const collapsed = panelRefs.current[id]?.getCollapsed();
+					]}
+					collapsed={props.resultsCollapsed}
+					onClick={(event) => {
+						event.preventDefault();
 
-						return (
-							<>
-								{idx !== 0 ? (
-									<PanelResizeHandle className="resize-handle" />
-								) : null}
-								<SectionHeader
-									title={title}
-									commands={commands}
-									defaultOpen={!collapsed}
-									onHeaderClick={() => togglePanel(id)}
-								/>
-								<ResizablePanel
-									collapsible
-									minSize={0}
-									defaultSize={50}
-									ref={(ref) => {
-										if (ref) {
-											panelRefs.current[id] = ref;
-										}
-									}}
-									style={{
-										overflowY: 'auto',
-										overflowX: 'hidden',
-										...inlineStyle,
-									}}
-								>
-									<Component {...props} />
-								</ResizablePanel>
-							</>
-						);
-					},
-				)}
+						vscode.postMessage({
+							kind: 'webview.global.collapseResultsPanel',
+							collapsed: !props.resultsCollapsed,
+						});
+					}}
+				/>
+				<ResizablePanel
+					collapsible
+					minSize={0}
+					defaultSize={props.panelGroupSettings['0,0']?.[0] ?? 50}
+					style={{
+						overflowY: 'auto',
+						overflowX: 'hidden',
+					}}
+					ref={resultsRef}
+					onCollapse={(collapsed) => {
+						vscode.postMessage({
+							kind: 'webview.global.collapseResultsPanel',
+							collapsed,
+						});
+					}}
+				>
+					<CampaignManager {...props} />
+				</ResizablePanel>
+				<PanelResizeHandle className="resize-handle" />
+				<SectionHeader
+					title={'Change Explorer'}
+					commands={[]}
+					collapsed={props.changeExplorerCollapsed}
+					onClick={(event) => {
+						event.preventDefault();
+
+						vscode.postMessage({
+							kind: 'webview.global.collapseChangeExplorerPanel',
+							collapsed: !props.changeExplorerCollapsed,
+						});
+					}}
+				/>
+				<ResizablePanel
+					collapsible
+					minSize={0}
+					defaultSize={props.panelGroupSettings['0,0']?.[1] ?? 50}
+					style={{
+						overflowY: 'auto',
+						overflowX: 'hidden',
+					}}
+					ref={changeExplorerRef}
+					onCollapse={(collapsed) => {
+						vscode.postMessage({
+							kind: 'webview.global.collapseChangeExplorerPanel',
+							collapsed,
+						});
+					}}
+				>
+					<FileExplorer {...props} />
+				</ResizablePanel>
 			</PanelGroup>
 		</div>
 	);
 };
-
-export default CodemodRuns;

--- a/intuita-webview/src/shared/SectionHeader/index.tsx
+++ b/intuita-webview/src/shared/SectionHeader/index.tsx
@@ -1,49 +1,37 @@
 import cn from 'classnames';
 import s from './style.module.css';
 import { Command } from 'vscode';
-import { ReactNode, useState } from 'react';
 import { vscode } from '../utilities/vscode';
 
-type Props = {
-	title: string;
-	defaultOpen: boolean;
-	commands: ReadonlyArray<Command & { icon: string }>;
-	children?: ReactNode;
-	onHeaderClick?(): void;
-};
-
-const handleCommand = (c: Command) => {
+const handleCommand = (value: Command) => {
 	vscode.postMessage({
 		kind: 'webview.command',
-		value: c,
+		value,
 	});
 };
 
-const SectionHeader = ({
-	defaultOpen,
-	title,
-	commands,
-	onHeaderClick,
-}: Props) => {
-	const [open, setOpen] = useState(defaultOpen);
+export const SectionHeader = (
+	props: Readonly<{
+		title: string;
+		collapsed: boolean;
+		commands: ReadonlyArray<Command & { icon: string }>;
+		onClick: React.MouseEventHandler<HTMLDivElement>;
+	}>,
+) => {
 	return (
-		<div
-			className={s.sectionHeader}
-			onClick={() => {
-				onHeaderClick?.();
-				setOpen((prev) => !prev);
-			}}
-		>
+		<div className={s.sectionHeader} onClick={props.onClick}>
 			<span
 				className={cn(
 					s.icon,
 					'codicon',
-					open ? 'codicon-chevron-down' : 'codicon-chevron-right',
+					!props.collapsed
+						? 'codicon-chevron-down'
+						: 'codicon-chevron-right',
 				)}
 			/>
-			<span className={s.title}> {title}</span>
+			<span className={s.title}>{props.title}</span>
 			<div className={s.commands}>
-				{(commands ?? []).map((c) => {
+				{props.commands.map((c) => {
 					return (
 						<span
 							key={c.command}
@@ -63,5 +51,3 @@ const SectionHeader = ({
 		</div>
 	);
 };
-
-export default SectionHeader;

--- a/src/components/webview/MainProvider.ts
+++ b/src/components/webview/MainProvider.ts
@@ -77,17 +77,8 @@ export class MainViewProvider implements WebviewViewProvider {
 		});
 
 		this.__messageBus.subscribe(MessageKind.executeCodemodSet, () => {
-			this.__postMessage({
-				kind: 'webview.main.setCollapsed',
-				collapsed: false,
-				viewName: 'codemodRunsView',
-			});
-
-			this.__postMessage({
-				kind: 'webview.main.setCollapsed',
-				collapsed: false,
-				viewName: 'changeExplorerView',
-			});
+			this.__store.dispatch(actions.collapseResultsPanel(false));
+			this.__store.dispatch(actions.collapseChangeExplorerPanel(false));
 		});
 
 		this.__messageBus.subscribe(
@@ -318,6 +309,18 @@ export class MainViewProvider implements WebviewViewProvider {
 		if (message.kind === 'webview.global.setCodemodSearchPhrase') {
 			this.__store.dispatch(
 				actions.setCodemodSearchPhrase(message.searchPhrase),
+			);
+		}
+
+		if (message.kind === 'webview.global.collapseResultsPanel') {
+			this.__store.dispatch(
+				actions.collapseResultsPanel(message.collapsed),
+			);
+		}
+
+		if (message.kind === 'webview.global.collapseChangeExplorerPanel') {
+			this.__store.dispatch(
+				actions.collapseChangeExplorerPanel(message.collapsed),
 			);
 		}
 	};

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -33,21 +33,10 @@ export type RunCodemodsCommand = Readonly<{
 	value: CodemodHash;
 }>;
 
-export type CollapsibleWebviews =
-	| 'codemodRunsView'
-	| 'codemodDiscoveryView'
-	| 'changeExplorerView'
-	| 'communityView';
-
 export type WebviewMessage =
 	| Readonly<{
 			kind: 'webview.setPanelViewProps';
 			panelViewProps: PanelViewProps;
-	  }>
-	| Readonly<{
-			kind: 'webview.main.setCollapsed';
-			collapsed: boolean;
-			viewName: CollapsibleWebviews;
 	  }>
 	| Readonly<{
 			kind: 'webview.error.setProps';
@@ -167,4 +156,12 @@ export type WebviewResponse =
 			kind: 'webview.panel.contentModified';
 			jobHash: JobHash;
 			newContent: string;
+	  }>
+	| Readonly<{
+			kind: 'webview.global.collapseResultsPanel';
+			collapsed: boolean;
+	  }>
+	| Readonly<{
+			kind: 'webview.global.collapseChangeExplorerPanel';
+			collapsed: boolean;
 	  }>;

--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -675,6 +675,12 @@ const rootSlice = createSlice({
 		setJobDiffViewVisible(state, action: PayloadAction<boolean>) {
 			state.jobDiffView.visible = action.payload;
 		},
+		collapseResultsPanel(state, action: PayloadAction<boolean>) {
+			state.codemodRunsTab.resultsCollapsed = action.payload;
+		},
+		collapseChangeExplorerPanel(state, action: PayloadAction<boolean>) {
+			state.codemodRunsTab.changeExplorerCollapsed = action.payload;
+		},
 	},
 });
 

--- a/src/selectors/selectMainWebviewViewProps.ts
+++ b/src/selectors/selectMainWebviewViewProps.ts
@@ -32,6 +32,9 @@ export const selectMainWebviewViewProps = (
 			codemodRunsTree: selectCodemodRunsTree(state, rootUri.fsPath),
 			changeExplorerTree: selectExplorerTree(state),
 			panelGroupSettings: state.codemodRunsTab.panelGroupSettings,
+			resultsCollapsed: state.codemodRunsTab.resultsCollapsed,
+			changeExplorerCollapsed:
+				state.codemodRunsTab.changeExplorerCollapsed,
 		};
 	}
 


### PR DESCRIPTION
Changes
* removed the `RESIZABLE_PANELS` constant and the way the CodemodRuns build the panels; now it's explicit
* introduced the `PanelGroupStorage` structure to support reading and writing of panel group's sizes
* collapse or expand panels when the store props change (including the changes stemming from user clicks and from the 3rd party library that ensures that one panel is always visible)
* add `collapseResultsPanel` and `collapseChangeExplorerPanel` actions AND webview responses
* remove the `CollapsibleWebviews` structure

[Screencast from 04.07.2023 16:53:47.webm](https://github.com/intuita-inc/intuita-vscode-extension/assets/35925521/fb0864bd-359d-457b-bc7a-f83626ad5702)
