### PR TITLE
collapse nested folders

### DIFF
--- a/src/selectors/selectExplorerTree.ts
+++ b/src/selectors/selectExplorerTree.ts
@@ -142,13 +142,11 @@ export const selectExplorerNodes = (
 
 	const explorerNodes: _ExplorerNode[] = [];
 
-	const appendExplorerNode = (hashDigest: _ExplorerNodeHashDigest) => {
-		let node = nodes[hashDigest] ?? null;
-
-		let selectedFilesCount = 0;
+	const collapseNodes = (hashDigest: _ExplorerNodeHashDigest) => {
+		const node = nodes[hashDigest] ?? null;
 
 		if (node === null) {
-			return selectedFilesCount;
+			return;
 		}
 
 		const childNodes = Array.from(children[node.hashDigest] ?? []).map(
@@ -163,13 +161,26 @@ export const selectExplorerNodes = (
 			};
 
 			nodes[node.hashDigest] = nextNode;
-			node = nextNode;
 
 			const grandchildren = children[firstChild.hashDigest] ?? new Set();
 
 			children[node.hashDigest] = grandchildren;
 			delete nodes[firstChild.hashDigest];
 			delete children[firstChild.hashDigest];
+
+			collapseNodes(node.hashDigest);
+		}
+	};
+
+	const appendExplorerNode = (hashDigest: _ExplorerNodeHashDigest) => {
+		collapseNodes(hashDigest);
+
+		const node = nodes[hashDigest] ?? null;
+
+		let selectedFilesCount = 0;
+
+		if (node === null) {
+			return selectedFilesCount;
 		}
 
 		selectedFilesCount = Array.from(children[node.hashDigest] ?? [])

--- a/src/selectors/selectExplorerTree.ts
+++ b/src/selectors/selectExplorerTree.ts
@@ -177,13 +177,13 @@ export const selectExplorerNodes = (
 
 		const node = nodes[hashDigest] ?? null;
 
-		let selectedFilesCount = 0;
+		let selectedFileCount = 0;
 
 		if (node === null) {
-			return selectedFilesCount;
+			return selectedFileCount;
 		}
 
-		selectedFilesCount = Array.from(children[node.hashDigest] ?? [])
+		selectedFileCount = Array.from(children[node.hashDigest] ?? [])
 			.map((childHash) => nodes[childHash])
 			.filter(
 				(node) =>
@@ -196,19 +196,19 @@ export const selectExplorerNodes = (
 		const pushedAtIndex = explorerNodes.push(node) - 1;
 
 		children[node.hashDigest]?.forEach((child) => {
-			selectedFilesCount += appendExplorerNode(child);
+			selectedFileCount += appendExplorerNode(child);
 		});
 
 		if (node.kind === 'FILE') {
-			return selectedFilesCount;
+			return selectedFileCount;
 		}
 
 		explorerNodes[pushedAtIndex] = {
 			...node,
-			childCount: selectedFilesCount,
+			childCount: selectedFileCount,
 		};
 
-		return selectedFilesCount;
+		return selectedFileCount;
 	};
 
 	appendExplorerNode(rootNode.hashDigest);


### PR DESCRIPTION
-- adds compact tree view, same as in vscode file explorer
<img width="347" alt="image" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/125881252/caf66e3e-4874-49fe-bc65-ee5cbc55d331">
<img width="287" alt="image" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/125881252/10e45565-7ac1-43c2-b866-c9672eaad197">
