### PR TITLE
INT-1313 add ability to run Piranha rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
 				"title": "Intuita: Run as a codemod"
 			},
 			{
+				"command": "intuita.executeAsPiranhaRule",
+				"title": "Intuita: Run as a Piranha Rule"
+			},
+			{
 				"command": "intuita.executeCodemod",
 				"title": "Intuita: Execute Codemod"
 			},
@@ -163,6 +167,10 @@
 					"when": "false"
 				},
 				{
+					"command": "intuita.executeAsPiranhaRule",
+					"when": "false"
+				},
+				{
 					"command": "intuita.executeCodemod",
 					"when": "false"
 				},
@@ -192,6 +200,11 @@
 					"command": "intuita.executeAsCodemod",
 					"group": "2_workspace",
 					"when": "resourceExtname == .js || resourceExtname == .ts"
+				},
+				{
+					"command": "intuita.executeAsPiranhaRule",
+					"group": "2_workspace",
+					"when": "explorerResourceIsFolder"
 				},
 				{
 					"command": "intuita.executeCodemodWithinPath",

--- a/src/components/bootstrapExecutablesService.ts
+++ b/src/components/bootstrapExecutablesService.ts
@@ -32,9 +32,14 @@ export class BootstrapExecutablesService {
 		const noraNodeEngineExecutableUri =
 			await this.#bootstrapNoraNodeEngineExecutableUri();
 
+		const codemodEngineNodeExecutableUri = Uri.parse(
+			'/intuita/codemod-engine-rust/target/release/codemod-engine-rust',
+		);
+
 		this.#messageBus.publish({
 			kind: MessageKind.engineBootstrapped,
 			noraNodeEngineExecutableUri,
+			codemodEngineNodeExecutableUri,
 		});
 	}
 

--- a/src/components/buildArguments.ts
+++ b/src/components/buildArguments.ts
@@ -1,0 +1,100 @@
+import { Uri } from 'vscode';
+import type { Configuration } from '../configuration';
+import type { Message, MessageKind } from './messageBus';
+import { doubleQuotify, singleQuotify } from '../utilities';
+
+export const buildArguments = (
+	configuration: Configuration,
+	message: Omit<
+		Message & { kind: MessageKind.executeCodemodSet },
+		'storageUri'
+	>,
+	storageUri: Uri,
+) => {
+	const args: string[] = [];
+
+	const { command } = message;
+
+	if (command.kind === 'executePiranhaRule') {
+		args.push('-i', singleQuotify(message.targetUri.fsPath));
+		args.push('-c', singleQuotify(command.configurationUri.fsPath));
+		args.push('-o', singleQuotify(storageUri.fsPath));
+
+		// configuration.includePatterns.forEach((includePattern) => {
+		// 	const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
+
+		// 	args.push('-p', singleQuotify(fsPath));
+		// });
+
+		// configuration.excludePatterns.forEach((excludePattern) => {
+		// 	const { fsPath } = Uri.joinPath(message.targetUri, excludePattern);
+
+		// 	args.push('-a', singleQuotify(fsPath));
+		// });
+
+		return args;
+	}
+
+	if (command.kind === 'executeRepomod') {
+		args.push('repomod');
+		args.push('-f', singleQuotify(command.codemodHash));
+		args.push('-i', singleQuotify(message.targetUri.fsPath));
+		args.push('-o', singleQuotify(storageUri.fsPath));
+
+		return args;
+	}
+
+	if (command.kind === 'executeCodemod') {
+		args.push('-c', singleQuotify(doubleQuotify(command.codemodHash)));
+
+		if (message.targetUriIsDirectory) {
+			configuration.includePatterns.forEach((includePattern) => {
+				const { fsPath } = Uri.joinPath(
+					message.targetUri,
+					includePattern,
+				);
+
+				args.push('-p', singleQuotify(fsPath));
+			});
+
+			configuration.excludePatterns.forEach((excludePattern) => {
+				const { fsPath } = Uri.joinPath(
+					message.targetUri,
+					excludePattern,
+				);
+
+				args.push('-p', `!${singleQuotify(fsPath)}`);
+			});
+		} else {
+			args.push('-p', singleQuotify(message.targetUri.fsPath));
+		}
+
+		args.push('-w', String(configuration.workerThreadCount));
+
+		args.push('-l', String(configuration.fileLimit));
+
+		args.push('-o', singleQuotify(storageUri.fsPath));
+
+		return args;
+	}
+
+	configuration.includePatterns.forEach((includePattern) => {
+		const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
+
+		args.push('-p', singleQuotify(fsPath));
+	});
+
+	configuration.excludePatterns.forEach((excludePattern) => {
+		const { fsPath } = Uri.joinPath(message.targetUri, excludePattern);
+
+		args.push('-p', `!${singleQuotify(fsPath)}`);
+	});
+
+	args.push('-w', String(configuration.workerThreadCount));
+
+	args.push('-l', String(configuration.fileLimit));
+	args.push('-f', singleQuotify(command.codemodUri.fsPath));
+	args.push('-o', singleQuotify(storageUri.fsPath));
+
+	return args;
+};

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -57,6 +57,10 @@ export type Command =
 	| Readonly<{
 			kind: 'executeLocalCodemod';
 			codemodUri: Uri;
+	  }>
+	| Readonly<{
+			kind: 'executePiranhaRule';
+			configurationUri: Uri;
 	  }>;
 
 export type Message =
@@ -99,6 +103,7 @@ export type Message =
 	| Readonly<{
 			kind: MessageKind.engineBootstrapped;
 			noraNodeEngineExecutableUri: Uri;
+			codemodEngineNodeExecutableUri: Uri;
 	  }>
 	| Readonly<{
 			kind: MessageKind.executeCodemodSet;
@@ -111,8 +116,6 @@ export type Message =
 	  }>
 	| Readonly<{
 			kind: MessageKind.codemodSetExecuted;
-			codemodName: string;
-			caseHashDigest: CaseHash;
 			halted: boolean;
 			fileCount: number;
 			jobs: Job[];

--- a/src/telemetry/vscodeTelemetry.ts
+++ b/src/telemetry/vscodeTelemetry.ts
@@ -80,23 +80,11 @@ export class VscodeTelemetry implements Telemetry {
 	__onCodemodSetExecuted(
 		message: Message & { kind: MessageKind.codemodSetExecuted },
 	): void {
-		const { halted, caseHashDigest, jobs, codemodName } = message;
-
-		if (halted) {
-			this.sendEvent({
-				kind: 'codemodHalted',
-				executionId: caseHashDigest,
-				fileCount: jobs.length,
-				codemodName,
-			});
-			return;
-		}
-
 		this.sendEvent({
-			kind: 'codemodExecuted',
-			executionId: caseHashDigest,
-			fileCount: jobs.length,
-			codemodName,
+			kind: message.halted ? 'codemodHalted' : 'codemodExecuted',
+			executionId: message.case.hash,
+			fileCount: message.jobs.length,
+			codemodName: message.case.codemodName,
 		});
 	}
 


### PR DESCRIPTION
Changes:
* added the `intuita.executeAsPiranhaRule` command,
* added the `codemodEngineNodeExecutableUri` (now hardcoded) URI,
* removed unused and doubled property from the `Execution` type,
* take the `codemodName` from the state or from the command