### PR TITLE
INT-1421 use the CLI (CEN) for fetching and running codemods

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,8 @@
 		"newtype-ts": "^0.3.5",
 		"prettier": "^2.8.8",
 		"redux-persist": "^6.0.0",
-		"semver": "^7.3.8"
+		"semver": "^7.3.8",
+		"@effect/schema": "0.30.3"
 	},
 	"extensionDependencies": [
 		"vscode.git"

--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
 		"mocha": "^10.2.0",
 		"ts-loader": "^9.4.2",
 		"ts-node": "^10.9.1",
-		"typescript": "^4.9.4",
+		"typescript": "5.1.6",
 		"umd-compat-loader": "^2.1.2",
 		"webpack": "^5.75.0",
 		"webpack-cli": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,10 +75,10 @@ devDependencies:
     version: 1.78.0
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.48.1
-    version: 5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@4.9.5)
+    version: 5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.1.6)
   '@typescript-eslint/parser':
     specifier: ^5.48.1
-    version: 5.59.5(eslint@8.40.0)(typescript@4.9.5)
+    version: 5.59.5(eslint@8.40.0)(typescript@5.1.6)
   '@vscode/test-electron':
     specifier: ^2.2.2
     version: 2.3.0
@@ -108,13 +108,13 @@ devDependencies:
     version: 10.2.0
   ts-loader:
     specifier: ^9.4.2
-    version: 9.4.2(typescript@4.9.5)(webpack@5.82.0)
+    version: 9.4.2(typescript@5.1.6)(webpack@5.82.0)
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@18.11.18)(typescript@4.9.5)
+    version: 10.9.1(@types/node@18.11.18)(typescript@5.1.6)
   typescript:
-    specifier: ^4.9.4
-    version: 4.9.5
+    specifier: 5.1.6
+    version: registry.npmjs.org/typescript@5.1.6
   umd-compat-loader:
     specifier: ^2.1.2
     version: 2.1.2
@@ -502,204 +502,6 @@ packages:
       fast-check: 3.11.0
     dev: false
 
-  /@esbuild/android-arm64@0.17.18:
-    resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-arm@0.17.18:
-    resolution: {integrity: sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/android-x64@0.17.18:
-    resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-arm64@0.17.18:
-    resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/darwin-x64@0.17.18:
-    resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-arm64@0.17.18:
-    resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/freebsd-x64@0.17.18:
-    resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm64@0.17.18:
-    resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-arm@0.17.18:
-    resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ia32@0.17.18:
-    resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-loong64@0.17.18:
-    resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-mips64el@0.17.18:
-    resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-ppc64@0.17.18:
-    resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-riscv64@0.17.18:
-    resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-s390x@0.17.18:
-    resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/linux-x64@0.17.18:
-    resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/netbsd-x64@0.17.18:
-    resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/openbsd-x64@0.17.18:
-    resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/sunos-x64@0.17.18:
-    resolution: {integrity: sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-arm64@0.17.18:
-    resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-ia32@0.17.18:
-    resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@esbuild/win32-x64@0.17.18:
-    resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@eslint-community/eslint-utils@4.4.0(eslint@8.40.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -839,7 +641,7 @@ packages:
       '@microsoft/applicationinsights-core-js': 2.8.13(tslib@2.5.0)
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
-      tslib: 2.5.0
+      tslib: registry.npmjs.org/tslib@2.5.0
     dev: false
 
   /@microsoft/applicationinsights-common@2.8.13(tslib@2.5.0):
@@ -850,7 +652,7 @@ packages:
       '@microsoft/applicationinsights-core-js': 2.8.13(tslib@2.5.0)
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
-      tslib: 2.5.0
+      tslib: registry.npmjs.org/tslib@2.5.0
     dev: false
 
   /@microsoft/applicationinsights-core-js@2.8.13(tslib@2.5.0):
@@ -860,7 +662,7 @@ packages:
     dependencies:
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
-      tslib: 2.5.0
+      tslib: registry.npmjs.org/tslib@2.5.0
     dev: false
 
   /@microsoft/applicationinsights-shims@2.0.2:
@@ -877,7 +679,7 @@ packages:
       '@microsoft/applicationinsights-core-js': 2.8.13(tslib@2.5.0)
       '@microsoft/applicationinsights-shims': 2.0.2
       '@microsoft/dynamicproto-js': 1.1.9
-      tslib: 2.5.0
+      tslib: registry.npmjs.org/tslib@2.5.0
     dev: false
 
   /@microsoft/applicationinsights-web-snippet@1.0.1:
@@ -1057,7 +859,7 @@ packages:
     resolution: {integrity: sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.59.5(@typescript-eslint/parser@5.59.5)(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1069,23 +871,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.5(eslint@8.40.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.59.5(eslint@8.40.0)(typescript@5.1.6)
       '@typescript-eslint/scope-manager': 5.59.5
-      '@typescript-eslint/type-utils': 5.59.5(eslint@8.40.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.59.5(eslint@8.40.0)(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: registry.npmjs.org/typescript@5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.5(eslint@8.40.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.59.5(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1097,10 +899,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.5
       '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.40.0
-      typescript: 4.9.5
+      typescript: registry.npmjs.org/typescript@5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1113,7 +915,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.5
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.5(eslint@8.40.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.59.5(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1123,12 +925,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.1.6)
+      '@typescript-eslint/utils': 5.59.5(eslint@8.40.0)(typescript@5.1.6)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.40.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: registry.npmjs.org/typescript@5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1138,7 +940,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.5(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.59.5(typescript@5.1.6):
     resolution: {integrity: sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1153,13 +955,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.1.6)
+      typescript: registry.npmjs.org/typescript@5.1.6
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.5(eslint@8.40.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.59.5(eslint@8.40.0)(typescript@5.1.6):
     resolution: {integrity: sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1170,7 +972,7 @@ packages:
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.59.5
       '@typescript-eslint/types': 5.59.5
-      '@typescript-eslint/typescript-estree': 5.59.5(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.59.5(typescript@5.1.6)
       eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -1644,7 +1446,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: registry.npmjs.org/fsevents@2.3.2
     dev: true
 
   /chrome-trace-event@1.0.3:
@@ -2039,28 +1841,28 @@ packages:
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.18
-      '@esbuild/android-arm64': 0.17.18
-      '@esbuild/android-x64': 0.17.18
-      '@esbuild/darwin-arm64': 0.17.18
-      '@esbuild/darwin-x64': 0.17.18
-      '@esbuild/freebsd-arm64': 0.17.18
-      '@esbuild/freebsd-x64': 0.17.18
-      '@esbuild/linux-arm': 0.17.18
-      '@esbuild/linux-arm64': 0.17.18
-      '@esbuild/linux-ia32': 0.17.18
-      '@esbuild/linux-loong64': 0.17.18
-      '@esbuild/linux-mips64el': 0.17.18
-      '@esbuild/linux-ppc64': 0.17.18
-      '@esbuild/linux-riscv64': 0.17.18
-      '@esbuild/linux-s390x': 0.17.18
-      '@esbuild/linux-x64': 0.17.18
-      '@esbuild/netbsd-x64': 0.17.18
-      '@esbuild/openbsd-x64': 0.17.18
-      '@esbuild/sunos-x64': 0.17.18
-      '@esbuild/win32-arm64': 0.17.18
-      '@esbuild/win32-ia32': 0.17.18
-      '@esbuild/win32-x64': 0.17.18
+      '@esbuild/android-arm': registry.npmjs.org/@esbuild/android-arm@0.17.18
+      '@esbuild/android-arm64': registry.npmjs.org/@esbuild/android-arm64@0.17.18
+      '@esbuild/android-x64': registry.npmjs.org/@esbuild/android-x64@0.17.18
+      '@esbuild/darwin-arm64': registry.npmjs.org/@esbuild/darwin-arm64@0.17.18
+      '@esbuild/darwin-x64': registry.npmjs.org/@esbuild/darwin-x64@0.17.18
+      '@esbuild/freebsd-arm64': registry.npmjs.org/@esbuild/freebsd-arm64@0.17.18
+      '@esbuild/freebsd-x64': registry.npmjs.org/@esbuild/freebsd-x64@0.17.18
+      '@esbuild/linux-arm': registry.npmjs.org/@esbuild/linux-arm@0.17.18
+      '@esbuild/linux-arm64': registry.npmjs.org/@esbuild/linux-arm64@0.17.18
+      '@esbuild/linux-ia32': registry.npmjs.org/@esbuild/linux-ia32@0.17.18
+      '@esbuild/linux-loong64': registry.npmjs.org/@esbuild/linux-loong64@0.17.18
+      '@esbuild/linux-mips64el': registry.npmjs.org/@esbuild/linux-mips64el@0.17.18
+      '@esbuild/linux-ppc64': registry.npmjs.org/@esbuild/linux-ppc64@0.17.18
+      '@esbuild/linux-riscv64': registry.npmjs.org/@esbuild/linux-riscv64@0.17.18
+      '@esbuild/linux-s390x': registry.npmjs.org/@esbuild/linux-s390x@0.17.18
+      '@esbuild/linux-x64': registry.npmjs.org/@esbuild/linux-x64@0.17.18
+      '@esbuild/netbsd-x64': registry.npmjs.org/@esbuild/netbsd-x64@0.17.18
+      '@esbuild/openbsd-x64': registry.npmjs.org/@esbuild/openbsd-x64@0.17.18
+      '@esbuild/sunos-x64': registry.npmjs.org/@esbuild/sunos-x64@0.17.18
+      '@esbuild/win32-arm64': registry.npmjs.org/@esbuild/win32-arm64@0.17.18
+      '@esbuild/win32-ia32': registry.npmjs.org/@esbuild/win32-ia32@0.17.18
+      '@esbuild/win32-x64': registry.npmjs.org/@esbuild/win32-x64@0.17.18
     dev: true
 
   /escalade@3.1.1:
@@ -2350,14 +2152,6 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
-
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
@@ -3190,7 +2984,7 @@ packages:
       react:
         optional: true
     dependencies:
-      redux: 4.2.1
+      redux: registry.npmjs.org/redux@4.2.1
     dev: false
 
   /redux-thunk@2.4.2(redux@4.2.1):
@@ -3487,7 +3281,7 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
-  /ts-loader@9.4.2(typescript@4.9.5)(webpack@5.82.0):
+  /ts-loader@9.4.2(typescript@5.1.6)(webpack@5.82.0):
     resolution: {integrity: sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -3498,11 +3292,11 @@ packages:
       enhanced-resolve: 5.13.0
       micromatch: 4.0.5
       semver: 7.5.0
-      typescript: 4.9.5
+      typescript: registry.npmjs.org/typescript@5.1.6
       webpack: 5.82.0(esbuild@0.17.18)(webpack-cli@5.1.1)
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.11.18)(typescript@4.9.5):
+  /ts-node@10.9.1(@types/node@18.11.18)(typescript@5.1.6):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -3528,7 +3322,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: registry.npmjs.org/typescript@5.1.6
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -3541,14 +3335,14 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: false
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.1.6):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: registry.npmjs.org/typescript@5.1.6
     dev: true
 
   /type-check@0.4.0:
@@ -3572,12 +3366,6 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
-    dev: true
-
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /umd-compat-loader@2.1.2:
@@ -3826,4 +3614,293 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  registry.npmjs.org/@babel/runtime@7.22.5:
+    resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz}
+    name: '@babel/runtime'
+    version: 7.22.5
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: registry.npmjs.org/regenerator-runtime@0.13.11
+    dev: false
+
+  registry.npmjs.org/@esbuild/android-arm64@0.17.18:
+    resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz}
+    name: '@esbuild/android-arm64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/android-arm@0.17.18:
+    resolution: {integrity: sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz}
+    name: '@esbuild/android-arm'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/android-x64@0.17.18:
+    resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz}
+    name: '@esbuild/android-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/darwin-arm64@0.17.18:
+    resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz}
+    name: '@esbuild/darwin-arm64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/darwin-x64@0.17.18:
+    resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz}
+    name: '@esbuild/darwin-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/freebsd-arm64@0.17.18:
+    resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz}
+    name: '@esbuild/freebsd-arm64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/freebsd-x64@0.17.18:
+    resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz}
+    name: '@esbuild/freebsd-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-arm64@0.17.18:
+    resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz}
+    name: '@esbuild/linux-arm64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-arm@0.17.18:
+    resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz}
+    name: '@esbuild/linux-arm'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-ia32@0.17.18:
+    resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz}
+    name: '@esbuild/linux-ia32'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-loong64@0.17.18:
+    resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz}
+    name: '@esbuild/linux-loong64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-mips64el@0.17.18:
+    resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz}
+    name: '@esbuild/linux-mips64el'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-ppc64@0.17.18:
+    resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz}
+    name: '@esbuild/linux-ppc64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-riscv64@0.17.18:
+    resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz}
+    name: '@esbuild/linux-riscv64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-s390x@0.17.18:
+    resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz}
+    name: '@esbuild/linux-s390x'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/linux-x64@0.17.18:
+    resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz}
+    name: '@esbuild/linux-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/netbsd-x64@0.17.18:
+    resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz}
+    name: '@esbuild/netbsd-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/openbsd-x64@0.17.18:
+    resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz}
+    name: '@esbuild/openbsd-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/sunos-x64@0.17.18:
+    resolution: {integrity: sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz}
+    name: '@esbuild/sunos-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/win32-arm64@0.17.18:
+    resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz}
+    name: '@esbuild/win32-arm64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/win32-ia32@0.17.18:
+    resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz}
+    name: '@esbuild/win32-ia32'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/@esbuild/win32-x64@0.17.18:
+    resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz}
+    name: '@esbuild/win32-x64'
+    version: 0.17.18
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
+    name: fsevents
+    version: 2.3.2
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  registry.npmjs.org/redux@4.2.1:
+    resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/redux/-/redux-4.2.1.tgz}
+    name: redux
+    version: 4.2.1
+    dependencies:
+      '@babel/runtime': registry.npmjs.org/@babel/runtime@7.22.5
+    dev: false
+
+  registry.npmjs.org/regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz}
+    name: regenerator-runtime
+    version: 0.13.11
+    dev: false
+
+  registry.npmjs.org/tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz}
+    name: tslib
+    version: 2.5.0
+    dev: false
+
+  registry.npmjs.org/typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==, registry: https://registry.yarnpkg.com/, tarball: https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz}
+    name: typescript
+    version: 5.1.6
+    engines: {node: '>=14.17'}
+    hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,10 +1,13 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@effect/schema':
+    specifier: 0.30.3
+    version: 0.30.3
   '@reduxjs/toolkit':
     specifier: ^1.9.5
     version: 1.9.5
@@ -480,6 +483,24 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
     dev: true
+
+  /@effect/data@0.16.3:
+    resolution: {integrity: sha512-RxRN3Vm8YPys0GjH/yjl2Z57kGCwJGjY6omgcDbeXhLVd+SUaVWbM6hJysKvb/gD9cuN1XwhXUnJ0shVErDelg==}
+    dev: false
+
+  /@effect/io@0.35.3:
+    resolution: {integrity: sha512-f0K2XQJvQY0DP6GQC76NUZgFh2QxKIpZZzIELyI8796uJtLt4CRx3s+YsJF68htgUttKm9hxkfcbtcJAg2Rmcw==}
+    dependencies:
+      '@effect/data': 0.16.3
+    dev: false
+
+  /@effect/schema@0.30.3:
+    resolution: {integrity: sha512-r56YgMiDbiOwMcUtIh/wTvrm5HQ8XGieAa16+fY1vfbQctNe+DFOWTmdohaERu6AZT6hfu5UBRFtDKL21sqWVA==}
+    dependencies:
+      '@effect/data': 0.16.3
+      '@effect/io': 0.35.3
+      fast-check: 3.11.0
+    dev: false
 
   /@esbuild/android-arm64@0.17.18:
     resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
@@ -2208,6 +2229,13 @@ packages:
     engines: {node: '>=0.8.x'}
     dev: true
 
+  /fast-check@3.11.0:
+    resolution: {integrity: sha512-H2tctb7AGfFQfz+DEr3UWhJ3s47LXsGp5g3jeJr5tHjnf4xUvpArIqiwcDmL2EXiv+auLHIpF5MqaIpIKvpxiA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      pure-rand: 6.0.2
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3102,6 +3130,10 @@ packages:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
     dev: true
+
+  /pure-rand@6.0.2:
+    resolution: {integrity: sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==}
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}

--- a/src/codemods/types.ts
+++ b/src/codemods/types.ts
@@ -10,7 +10,6 @@ export const codemodEntryCodec = t.union([
 			t.literal('jscodeshift'),
 			t.literal('ts-morph'),
 			t.literal('repomod-engine'),
-			t.literal('filemod-engine'),
 		]),
 	}),
 	buildTypeCodec({
@@ -24,3 +23,10 @@ export const codemodEntryCodec = t.union([
 ]);
 
 export type CodemodEntry = t.TypeOf<typeof codemodEntryCodec>;
+
+export const codemodNamesCodec = buildTypeCodec({
+	kind: t.literal('names'),
+	names: t.readonlyArray(t.string),
+});
+
+export type CodemodNames = t.TypeOf<typeof codemodNamesCodec>;

--- a/src/codemods/types.ts
+++ b/src/codemods/types.ts
@@ -17,8 +17,6 @@ export const codemodEntryCodec = t.union([
 		hashDigest: t.string,
 		name: t.string,
 		language: t.string,
-		configurationDirectoryBasename: t.string, // TO BE REMOVED
-		rulesTomlFileBasename: t.string, // TO BE REMOVED
 	}),
 ]);
 

--- a/src/codemods/types.ts
+++ b/src/codemods/types.ts
@@ -17,8 +17,8 @@ export const codemodEntryCodec = t.union([
 		hashDigest: t.string,
 		name: t.string,
 		language: t.string,
-		configurationDirectoryBasename: t.string,
-		rulesTomlFileBasename: t.string,
+		configurationDirectoryBasename: t.string, // TO BE REMOVED
+		rulesTomlFileBasename: t.string, // TO BE REMOVED
 	}),
 ]);
 

--- a/src/components/bootstrapExecutablesService.ts
+++ b/src/components/bootstrapExecutablesService.ts
@@ -19,8 +19,10 @@ export class BootstrapExecutablesService {
 		await this.__fileSystem.createDirectory(this.__globalStorageUri);
 
 		// Uri.file('/intuita/nora-node-engine/apps/nne/build/nne-linux')
-		const codemodEngineNodeExecutableUri =
-			await this.__bootstrapCodemodEngineNodeExecutableUri();
+		const codemodEngineNodeExecutableUri = Uri.file(
+			'/intuita/codemod-engine-node/package/intuita-linux',
+		);
+		// await this.__bootstrapCodemodEngineNodeExecutableUri();
 
 		// Uri.file('/intuita/codemod-engine-rust/target/release/codemod-engine-rust');
 		const codemodEngineRustExecutableUri =

--- a/src/components/bootstrapExecutablesService.ts
+++ b/src/components/bootstrapExecutablesService.ts
@@ -18,11 +18,9 @@ export class BootstrapExecutablesService {
 	private async __onBootstrapEngines() {
 		await this.__fileSystem.createDirectory(this.__globalStorageUri);
 
-		// Uri.file('/intuita/nora-node-engine/apps/nne/build/nne-linux')
-		const codemodEngineNodeExecutableUri = Uri.file(
-			'/intuita/codemod-engine-node/package/intuita-linux',
-		);
-		// await this.__bootstrapCodemodEngineNodeExecutableUri();
+		// Uri.file('/intuita/nora-node-engine/package/intuita-linux')
+		const codemodEngineNodeExecutableUri =
+			await this.__bootstrapCodemodEngineNodeExecutableUri();
 
 		// Uri.file('/intuita/codemod-engine-rust/target/release/codemod-engine-rust');
 		const codemodEngineRustExecutableUri =
@@ -41,7 +39,7 @@ export class BootstrapExecutablesService {
 				? 'macos'
 				: encodeURIComponent(process.platform);
 
-		const executableBaseName = `codemod-engine-node-${platform}`;
+		const executableBaseName = `intuita-${platform}`;
 
 		const executableUri = Uri.joinPath(
 			this.__globalStorageUri,
@@ -50,7 +48,7 @@ export class BootstrapExecutablesService {
 
 		try {
 			await this.__downloadService.downloadFileIfNeeded(
-				`https://intuita-public.s3.us-west-1.amazonaws.com/codemod-engine-node/${executableBaseName}`,
+				`https://intuita-public.s3.us-west-1.amazonaws.com/intuita/${executableBaseName}`,
 				executableUri,
 				'755',
 			);

--- a/src/components/buildArguments.ts
+++ b/src/components/buildArguments.ts
@@ -1,7 +1,7 @@
 import { Uri } from 'vscode';
 import type { Configuration } from '../configuration';
 import type { Message, MessageKind } from './messageBus';
-import { doubleQuotify, singleQuotify } from '../utilities';
+import { singleQuotify } from '../utilities';
 
 export const buildArguments = (
 	configuration: Configuration,
@@ -52,7 +52,7 @@ export const buildArguments = (
 
 	if (command.kind === 'executeCodemod') {
 		const args: string[] = [];
-		args.push('-c', singleQuotify(doubleQuotify(command.codemodHash)));
+		args.push('--name', singleQuotify(command.name));
 
 		if (message.targetUriIsDirectory) {
 			configuration.includePatterns.forEach((includePattern) => {
@@ -61,7 +61,7 @@ export const buildArguments = (
 					includePattern,
 				);
 
-				args.push('-p', singleQuotify(fsPath));
+				args.push('--includePattern', singleQuotify(fsPath));
 			});
 
 			configuration.excludePatterns.forEach((excludePattern) => {
@@ -70,17 +70,20 @@ export const buildArguments = (
 					excludePattern,
 				);
 
-				args.push('-p', `!${singleQuotify(fsPath)}`);
+				args.push('--excludePattern', `!${singleQuotify(fsPath)}`);
 			});
 		} else {
-			args.push('-p', singleQuotify(message.targetUri.fsPath));
+			args.push(
+				'--includePattern',
+				singleQuotify(message.targetUri.fsPath),
+			);
 		}
 
-		args.push('-w', String(configuration.workerThreadCount));
+		args.push('--threadCount', String(configuration.workerThreadCount));
 
-		args.push('-l', String(configuration.fileLimit));
+		args.push('--fileLimit', String(configuration.fileLimit));
 
-		args.push('-o', singleQuotify(storageUri.fsPath));
+		args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
 
 		args.push(
 			'--formatWithPrettier',
@@ -95,24 +98,25 @@ export const buildArguments = (
 	configuration.includePatterns.forEach((includePattern) => {
 		const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
 
-		args.push('-p', singleQuotify(fsPath));
+		args.push('--includePattern', singleQuotify(fsPath));
 	});
 
 	configuration.excludePatterns.forEach((excludePattern) => {
 		const { fsPath } = Uri.joinPath(message.targetUri, excludePattern);
 
-		args.push('-p', `!${singleQuotify(fsPath)}`);
+		args.push('--excludePattern', `!${singleQuotify(fsPath)}`);
 	});
 
-	args.push('-w', String(configuration.workerThreadCount));
+	args.push('--threadCount', String(configuration.workerThreadCount));
 
-	args.push('-l', String(configuration.fileLimit));
+	args.push('--fileLimit', String(configuration.fileLimit));
 
-	args.push('-f', singleQuotify(command.codemodUri.fsPath));
+	args.push('--sourcePath', singleQuotify(command.codemodUri.fsPath));
+	args.push('--codemodEngine', 'jscodeshift');
 
-	args.push('-o', singleQuotify(storageUri.fsPath));
+	args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
 
-	args.push('--formatWithPrettier', String(configuration.formatWithPrettier));
+	args.push('--usePrettier', String(configuration.formatWithPrettier));
 
 	return args;
 };

--- a/src/components/buildArguments.ts
+++ b/src/components/buildArguments.ts
@@ -35,94 +35,40 @@ export const buildArguments = (
 		return args;
 	}
 
-	if (command.kind === 'executeRepomod') {
-		const args: string[] = [];
-		args.push('repomod');
-		args.push('-f', singleQuotify(command.codemodHash));
-		args.push('-i', singleQuotify(message.targetUri.fsPath));
-		args.push('-o', singleQuotify(storageUri.fsPath));
-
-		args.push(
-			'--formatWithPrettier',
-			String(configuration.formatWithPrettier),
-		);
-
-		return args;
-	}
-
-	if (command.kind === 'executeCodemod') {
-		const args: string[] = [];
-		args.push('--name', singleQuotify(command.name));
-
-		if (message.targetUriIsDirectory) {
-			configuration.includePatterns.forEach((includePattern) => {
-				const { fsPath } = Uri.joinPath(
-					message.targetUri,
-					includePattern,
-				);
-
-				args.push('--includePattern', singleQuotify(fsPath));
-			});
-
-			configuration.excludePatterns.forEach((excludePattern) => {
-				const { fsPath } = Uri.joinPath(
-					message.targetUri,
-					excludePattern,
-				);
-
-				args.push('--excludePattern', `!${singleQuotify(fsPath)}`);
-			});
-		} else {
-			args.push(
-				'--includePattern',
-				singleQuotify(message.targetUri.fsPath),
-			);
-		}
-
-		args.push('--threadCount', String(configuration.workerThreadCount));
-
-		args.push('--fileLimit', String(configuration.fileLimit));
-
-		args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
-
-		args.push(
-			'--formatWithPrettier',
-			String(configuration.formatWithPrettier),
-		);
-
-		args.push('--useJson');
-		args.push('--useCache');
-
-		return args;
-	}
-
 	const args: string[] = [];
 
-	configuration.includePatterns.forEach((includePattern) => {
-		const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
+	if (message.targetUriIsDirectory) {
+		configuration.includePatterns.forEach((includePattern) => {
+			const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
 
-		args.push('--includePattern', singleQuotify(fsPath));
-	});
+			args.push('--includePattern', singleQuotify(fsPath));
+		});
 
-	configuration.excludePatterns.forEach((excludePattern) => {
-		const { fsPath } = Uri.joinPath(message.targetUri, excludePattern);
+		configuration.excludePatterns.forEach((excludePattern) => {
+			const { fsPath } = Uri.joinPath(message.targetUri, excludePattern);
 
-		args.push('--excludePattern', `!${singleQuotify(fsPath)}`);
-	});
+			args.push('--excludePattern', `!${singleQuotify(fsPath)}`);
+		});
+	} else {
+		args.push('--includePattern', singleQuotify(message.targetUri.fsPath));
+	}
 
 	args.push('--threadCount', String(configuration.workerThreadCount));
-
 	args.push('--fileLimit', String(configuration.fileLimit));
 
-	args.push('--sourcePath', singleQuotify(command.codemodUri.fsPath));
-	args.push('--codemodEngine', 'jscodeshift');
-
-	args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
-
 	args.push('--usePrettier', String(configuration.formatWithPrettier));
-
 	args.push('--useJson');
 	args.push('--useCache');
+
+	args.push('--dryRun');
+	args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
+
+	if (command.kind === 'executeCodemod') {
+		args.push('--name', singleQuotify(command.name));
+	} else {
+		args.push('--sourcePath', singleQuotify(command.codemodUri.fsPath));
+		args.push('--codemodEngine', 'jscodeshift');
+	}
 
 	return args;
 };

--- a/src/components/buildArguments.ts
+++ b/src/components/buildArguments.ts
@@ -90,6 +90,9 @@ export const buildArguments = (
 			String(configuration.formatWithPrettier),
 		);
 
+		args.push('--useJson');
+		args.push('--useCache');
+
 		return args;
 	}
 
@@ -117,6 +120,9 @@ export const buildArguments = (
 	args.push('--outputDirectoryPath', singleQuotify(storageUri.fsPath));
 
 	args.push('--usePrettier', String(configuration.formatWithPrettier));
+
+	args.push('--useJson');
+	args.push('--useCache');
 
 	return args;
 };

--- a/src/components/buildArguments.ts
+++ b/src/components/buildArguments.ts
@@ -37,6 +37,8 @@ export const buildArguments = (
 
 	const args: string[] = [];
 
+	args.push('--inputDirectoryPath', singleQuotify(message.targetUri.fsPath));
+
 	if (message.targetUriIsDirectory) {
 		configuration.includePatterns.forEach((includePattern) => {
 			const { fsPath } = Uri.joinPath(message.targetUri, includePattern);
@@ -56,7 +58,10 @@ export const buildArguments = (
 	args.push('--threadCount', String(configuration.workerThreadCount));
 	args.push('--fileLimit', String(configuration.fileLimit));
 
-	args.push('--usePrettier', String(configuration.formatWithPrettier));
+	if (configuration.formatWithPrettier) {
+		args.push('--usePrettier');
+	}
+
 	args.push('--useJson');
 	args.push('--useCache');
 

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -250,25 +250,25 @@ export class EngineService {
 			throw new Error('The engines are not bootstrapped.');
 		}
 
-		// const childProcess = spawn(
-		// 	singleQuotify(this.__codemodEngineNodeExecutableUri.fsPath),
-		// 	['syncRegistry'],
-		// 	{
-		// 		stdio: 'pipe',
-		// 		shell: true,
-		// 		detached: false,
-		// 	},
-		// );
+		const childProcess = spawn(
+			singleQuotify(this.__codemodEngineNodeExecutableUri.fsPath),
+			['syncRegistry'],
+			{
+				stdio: 'pipe',
+				shell: true,
+				detached: false,
+			},
+		);
 
-		// return new Promise<void>((resolve, reject) => {
-		// 	childProcess.once('exit', () => {
-		// 		resolve();
-		// 	});
+		return new Promise<void>((resolve, reject) => {
+			childProcess.once('exit', () => {
+				resolve();
+			});
 
-		// 	childProcess.once('error', (error) => {
-		// 		reject(error);
-		// 	});
-		// });
+			childProcess.once('error', (error) => {
+				reject(error);
+			});
+		});
 	}
 
 	public async getCodemodList(): Promise<ReadonlyArray<string>> {
@@ -390,7 +390,7 @@ export class EngineService {
 				// TODO handle recipe
 			}
 
-			this.__store.dispatch(actions.upsertCodemods(codemodEntries));
+			this.__store.dispatch(actions.setCodemods(codemodEntries));
 		} catch (e) {
 			console.error(e);
 		}

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -369,8 +369,6 @@ export class EngineService {
 						hashDigest,
 						name,
 						language: config.engine,
-						configurationDirectoryBasename: '', // to be removed
-						rulesTomlFileBasename: '', // to be removed
 					});
 
 					continue;

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -154,14 +154,14 @@ export class EngineService {
 		return this.__codemodEngineNodeExecutableUri !== null;
 	}
 
-	private async __syncRegistry() {
+	private async __syncRegistry(): Promise<void> {
 		if (this.__codemodEngineNodeExecutableUri === null) {
 			throw new Error('The engines are not bootstrapped.');
 		}
 
 		const childProcess = spawn(
 			singleQuotify(this.__codemodEngineNodeExecutableUri.fsPath),
-			['listNames', '--useJson', '--useCache'],
+			['syncRegistry'],
 			{
 				stdio: 'pipe',
 				shell: true,
@@ -169,7 +169,7 @@ export class EngineService {
 			},
 		);
 
-		new Promise<void>((resolve, reject) => {
+		return new Promise<void>((resolve, reject) => {
 			childProcess.once('exit', () => {
 				resolve();
 			});
@@ -253,6 +253,8 @@ export class EngineService {
 			);
 
 			const codemodEntries: CodemodEntry[] = [];
+
+			console.log('names', names);
 
 			for (const name of names) {
 				const hashDigest = createHash('ripemd160')

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -779,8 +779,6 @@ export class EngineService {
 		});
 
 		interfase.on('close', async () => {
-			console.log('on close');
-
 			if (this.#execution) {
 				this.#messageBus.publish({
 					kind: MessageKind.codemodSetExecuted,

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -537,8 +537,6 @@ export class EngineService {
 			storageUri,
 		);
 
-		console.log('TEST', args.join(' '));
-
 		const childProcess = spawn(
 			singleQuotify(
 				message.command.kind === 'executePiranhaRule'
@@ -612,8 +610,6 @@ export class EngineService {
 		let timer: NodeJS.Timeout | null = null;
 
 		interfase.on('line', async (line) => {
-			console.log(line);
-
 			if (timer !== null) {
 				clearTimeout(timer);
 			}

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -539,6 +539,8 @@ export class EngineService {
 			storageUri,
 		);
 
+		console.log('TEST', args.join(' '));
+
 		const childProcess = spawn(
 			singleQuotify(
 				message.command.kind === 'executePiranhaRule'

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -250,25 +250,25 @@ export class EngineService {
 			throw new Error('The engines are not bootstrapped.');
 		}
 
-		const childProcess = spawn(
-			singleQuotify(this.__codemodEngineNodeExecutableUri.fsPath),
-			['syncRegistry'],
-			{
-				stdio: 'pipe',
-				shell: true,
-				detached: false,
-			},
-		);
+		// const childProcess = spawn(
+		// 	singleQuotify(this.__codemodEngineNodeExecutableUri.fsPath),
+		// 	['syncRegistry'],
+		// 	{
+		// 		stdio: 'pipe',
+		// 		shell: true,
+		// 		detached: false,
+		// 	},
+		// );
 
-		return new Promise<void>((resolve, reject) => {
-			childProcess.once('exit', () => {
-				resolve();
-			});
+		// return new Promise<void>((resolve, reject) => {
+		// 	childProcess.once('exit', () => {
+		// 		resolve();
+		// 	});
 
-			childProcess.once('error', (error) => {
-				reject(error);
-			});
-		});
+		// 	childProcess.once('error', (error) => {
+		// 		reject(error);
+		// 	});
+		// });
 	}
 
 	public async getCodemodList(): Promise<ReadonlyArray<string>> {
@@ -514,7 +514,6 @@ export class EngineService {
 
 		const codemodHash =
 			message.command.kind === 'executeCodemod' ||
-			message.command.kind === 'executeRepomod' ||
 			message.command.kind === 'executeLocalCodemod'
 				? message.command.codemodHash
 				: null;
@@ -564,6 +563,8 @@ export class EngineService {
 				return;
 			}
 
+			console.error(chunk.toString());
+
 			try {
 				const stringifiedChunk = JSON.stringify(chunk.toString());
 
@@ -611,6 +612,8 @@ export class EngineService {
 		let timer: NodeJS.Timeout | null = null;
 
 		interfase.on('line', async (line) => {
+			console.log(line);
+
 			if (timer !== null) {
 				clearTimeout(timer);
 			}
@@ -776,6 +779,8 @@ export class EngineService {
 		});
 
 		interfase.on('close', async () => {
+			console.log('on close');
+
 			if (this.#execution) {
 				this.#messageBus.publish({
 					kind: MessageKind.codemodSetExecuted,

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -227,7 +227,7 @@ export class EngineService {
 		});
 	}
 
-	#onEnginesBootstrappedMessage(
+	async #onEnginesBootstrappedMessage(
 		message: Message & { kind: MessageKind.engineBootstrapped },
 	) {
 		this.__codemodEngineNodeExecutableUri =
@@ -235,10 +235,10 @@ export class EngineService {
 		this.__codemodEngineRustExecutableUri =
 			message.codemodEngineRustExecutableUri;
 
-		this.__syncRegistry();
+		await this.__syncRegistry();
 
-		this.__fetchCodemods();
-		this.fetchPrivateCodemods();
+		await this.__fetchCodemods();
+		await this.fetchPrivateCodemods();
 	}
 
 	public isEngineBootstrapped() {
@@ -271,7 +271,7 @@ export class EngineService {
 		});
 	}
 
-	public async getCodemodList(): Promise<ReadonlyArray<string>> {
+	public async __getCodemodNames(): Promise<ReadonlyArray<string>> {
 		const executableUri = this.__codemodEngineNodeExecutableUri;
 
 		if (executableUri === null) {
@@ -316,7 +316,7 @@ export class EngineService {
 
 	private async __fetchCodemods(): Promise<void> {
 		try {
-			const names = await this.getCodemodList();
+			const names = await this.__getCodemodNames();
 
 			const codemodConfigSchema = S.union(
 				S.struct({

--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -268,9 +268,9 @@ export class EngineService {
 
 				const data = await readFile(configPath, 'utf8');
 
-				const configObject = JSON.parse(configPath);
-
-				const config = S.parseSync(codemodConfigSchema)(configObject);
+				const config = S.parseSync(codemodConfigSchema)(
+					JSON.parse(data),
+				);
 
 				if (config.engine === 'piranha') {
 					codemodEntries.push({

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -47,11 +47,6 @@ export const enum MessageKind {
 
 export type Command =
 	| Readonly<{
-			kind: 'executeRepomod';
-			codemodHash: CodemodHash;
-			name: string;
-	  }>
-	| Readonly<{
 			kind: 'executeCodemod';
 			codemodHash: CodemodHash;
 			name: string;

--- a/src/components/webview/CodemodDescriptionProvider.ts
+++ b/src/components/webview/CodemodDescriptionProvider.ts
@@ -1,200 +1,39 @@
 import { EventEmitter, FileSystem, Uri } from 'vscode';
-import { MessageBus, MessageKind } from '../messageBus';
-import { buildCodemodMetadataHash, buildTypeCodec } from '../../utilities';
-import * as t from 'io-ts';
-import * as E from 'fp-ts/Either';
-import { DownloadService } from '../downloadService';
-import { CodemodEntry, codemodEntryCodec } from '../../codemods/types';
-import { Store } from '../../data';
-import { actions } from '../../data/slice';
-
-const indexItemCodec = buildTypeCodec({
-	kind: t.literal('README'),
-	name: t.string,
-	path: t.string,
-});
-
-const BASE_URL = `https://intuita-public.s3.us-west-1.amazonaws.com`;
+import { buildCodemodMetadataHash } from '../../utilities';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 
 export class CodemodDescriptionProvider {
 	private __descriptions = new Map<string, string>();
 	public onDidChangeEmitter = new EventEmitter<null>();
 	public onDidChange = this.onDidChangeEmitter.event;
 
-	constructor(
-		private readonly __downloadService: DownloadService,
-		private readonly __fileSystem: FileSystem,
-		private readonly __globalStorageUri: Uri,
-		private readonly __messageBus: MessageBus,
-		private readonly __store: Store,
-	) {
-		this.__messageBus.subscribe(MessageKind.engineBootstrapped, () =>
-			this.__onEngineBootstrapped(),
-		);
-	}
+	constructor(private readonly __fileSystem: FileSystem) {}
 
 	public getCodemodDescription(name: string): string {
 		const hash = buildCodemodMetadataHash(name);
 
+		const hashDigest = createHash('ripemd160')
+			.update(name)
+			.digest('base64url');
+
+		const path = join(homedir(), '.intuita', hashDigest, 'description.md');
+
 		const data = this.__descriptions.get(hash) ?? null;
 
 		if (data === null) {
-			this.__readDataFromFileSystem(hash)
-				.then((data) => {
-					this.__descriptions.set(hash, data);
+			this.__fileSystem.readFile(Uri.file(path)).then((uint8array) => {
+				const data = uint8array.toString();
 
-					this.onDidChangeEmitter.fire(null);
-				})
-				.catch((error) => {
-					console.error(error);
-				});
+				this.__descriptions.set(hash, data);
+
+				this.onDidChangeEmitter.fire(null);
+			});
 
 			return 'The documentation for this codemod is missing.';
 		}
 
 		return data;
-	}
-
-	private async __onEngineBootstrapped() {
-		await this.__fetchCodemods();
-
-		try {
-			await this.__fileSystem.createDirectory(this.__globalStorageUri);
-
-			const indexJsonUri = Uri.joinPath(
-				this.__globalStorageUri,
-				'index.json',
-			);
-
-			const url = `${BASE_URL}/codemod-registry/index.json`;
-
-			const downloaded =
-				await this.__downloadService.downloadFileIfNeeded(
-					url,
-					indexJsonUri,
-					null,
-				);
-
-			if (!downloaded) {
-				return;
-			}
-
-			const uint8array = await this.__fileSystem.readFile(indexJsonUri);
-			const data = uint8array.toString();
-
-			const validation = t
-				.readonlyArray(indexItemCodec)
-				.decode(JSON.parse(data));
-
-			if (E.isLeft(validation)) {
-				throw new Error('Could not decode the response');
-			}
-
-			for (const indexItem of validation.right) {
-				const metadata = await this.__fetchCodemodMetadata(
-					indexItem.path,
-				);
-
-				if (metadata === null) {
-					continue;
-				}
-
-				const hash = buildCodemodMetadataHash(indexItem.name);
-
-				this.__descriptions.set(hash, metadata);
-			}
-
-			this.onDidChangeEmitter.fire(null);
-		} catch (error) {
-			console.error(error);
-		}
-	}
-
-	private async __fetchCodemods() {
-		try {
-			await this.__fileSystem.createDirectory(this.__globalStorageUri);
-
-			const codemodsJsonUri = Uri.joinPath(
-				this.__globalStorageUri,
-				'codemods.json',
-			);
-
-			await this.__downloadService.downloadFileIfNeeded(
-				`${BASE_URL}/codemod-registry/codemods.json`,
-				codemodsJsonUri,
-				null,
-			);
-
-			const uint8array = await this.__fileSystem.readFile(
-				codemodsJsonUri,
-			);
-
-			const validation = t
-				.readonlyArray(codemodEntryCodec)
-				.decode(JSON.parse(uint8array.toString()));
-
-			if (E.isLeft(validation)) {
-				throw new Error('Could not decode the response');
-			}
-
-			const codemods = validation.right;
-
-			for (const codemod of codemods) {
-				if (codemod.kind !== 'piranhaRule') {
-					continue;
-				}
-
-				this.__fetchPiranhaConfiguration(codemod);
-			}
-
-			// this.__store.dispatch(actions.upsertCodemods(codemods));
-		} catch (error) {
-			console.error(error);
-		}
-	}
-
-	private async __fetchPiranhaConfiguration(
-		codemod: CodemodEntry & { kind: 'piranhaRule' },
-	): Promise<void> {
-		try {
-			const url = `${BASE_URL}/codemod-registry/${codemod.rulesTomlFileBasename}`;
-
-			const configurationDirectoryUri = Uri.joinPath(
-				this.__globalStorageUri,
-				codemod.configurationDirectoryBasename,
-			);
-
-			const uri = Uri.joinPath(configurationDirectoryUri, 'rules.toml');
-
-			await this.__fileSystem.createDirectory(configurationDirectoryUri);
-
-			await this.__downloadService.downloadFileIfNeeded(url, uri, null);
-		} catch (error) {
-			console.error(error);
-		}
-	}
-
-	private async __fetchCodemodMetadata(path: string): Promise<string | null> {
-		try {
-			const url = `${BASE_URL}/codemod-registry/${path}`;
-
-			const uri = Uri.joinPath(this.__globalStorageUri, path);
-
-			await this.__downloadService.downloadFileIfNeeded(url, uri, null);
-
-			const uint8array = await this.__fileSystem.readFile(uri);
-
-			return uint8array.toString();
-		} catch (e) {
-			return null;
-		}
-	}
-
-	private async __readDataFromFileSystem(hash: string): Promise<string> {
-		const storageUri = Uri.joinPath(this.__globalStorageUri, `${hash}.md`);
-
-		const uint8array = await this.__fileSystem.readFile(storageUri);
-
-		return uint8array.toString();
 	}
 }

--- a/src/components/webview/CodemodDescriptionProvider.ts
+++ b/src/components/webview/CodemodDescriptionProvider.ts
@@ -147,7 +147,7 @@ export class CodemodDescriptionProvider {
 				this.__fetchPiranhaConfiguration(codemod);
 			}
 
-			this.__store.dispatch(actions.upsertCodemods(codemods));
+			// this.__store.dispatch(actions.upsertCodemods(codemods));
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -70,7 +70,7 @@ const buildStore = async (workspaceState: Memento) => {
 	}
 
 	const store = configureStore({
-		reducer: validatedReducer,
+		reducer: rootReducer,
 		// preloadedState: decodedState.right,
 	});
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -42,17 +42,17 @@ const buildStore = async (workspaceState: Memento) => {
 	const validatedReducer: Reducer<
 		(RootState & PersistPartial) | undefined
 	> = (state, action) => {
-		if (action.type === 'persist/REHYDRATE') {
-			const decoded = persistedStateCodecNew.decode(action.payload);
+		// if (action.type === 'persist/REHYDRATE') {
+		// 	const decoded = persistedStateCodecNew.decode(action.payload);
 
-			const validatedPayload =
-				decoded._tag === 'Right' ? decoded.right : getInitialState();
+		// 	const validatedPayload =
+		// 		decoded._tag === 'Right' ? decoded.right : getInitialState();
 
-			return persistedReducer(state, {
-				...action,
-				payload: validatedPayload,
-			});
-		}
+		// 	return persistedReducer(state, {
+		// 		...action,
+		// 		payload: validatedPayload,
+		// 	});
+		// }
 
 		return persistedReducer(state, action);
 	};
@@ -71,7 +71,7 @@ const buildStore = async (workspaceState: Memento) => {
 
 	const store = configureStore({
 		reducer: validatedReducer,
-		preloadedState: decodedState.right,
+		// preloadedState: decodedState.right,
 	});
 
 	const persistor = persistStore(store);

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -42,17 +42,17 @@ const buildStore = async (workspaceState: Memento) => {
 	const validatedReducer: Reducer<
 		(RootState & PersistPartial) | undefined
 	> = (state, action) => {
-		// if (action.type === 'persist/REHYDRATE') {
-		// 	const decoded = persistedStateCodecNew.decode(action.payload);
+		if (action.type === 'persist/REHYDRATE') {
+			const decoded = persistedStateCodecNew.decode(action.payload);
 
-		// 	const validatedPayload =
-		// 		decoded._tag === 'Right' ? decoded.right : getInitialState();
+			const validatedPayload =
+				decoded._tag === 'Right' ? decoded.right : getInitialState();
 
-		// 	return persistedReducer(state, {
-		// 		...action,
-		// 		payload: validatedPayload,
-		// 	});
-		// }
+			return persistedReducer(state, {
+				...action,
+				payload: validatedPayload,
+			});
+		}
 
 		return persistedReducer(state, action);
 	};
@@ -70,8 +70,8 @@ const buildStore = async (workspaceState: Memento) => {
 	}
 
 	const store = configureStore({
-		reducer: rootReducer,
-		// preloadedState: decodedState.right,
+		reducer: validatedReducer,
+		preloadedState: decodedState.right,
 	});
 
 	const persistor = persistStore(store);

--- a/src/data/slice.ts
+++ b/src/data/slice.ts
@@ -151,11 +151,8 @@ const rootSlice = createSlice({
 			state.reviewedExplorerNodes = {};
 			state.focusedExplorerNodes = {};
 		},
-		upsertCodemods(
-			state,
-			action: PayloadAction<ReadonlyArray<CodemodEntry>>,
-		) {
-			codemodAdapter.upsertMany(state.codemod, action.payload);
+		setCodemods(state, action: PayloadAction<ReadonlyArray<CodemodEntry>>) {
+			codemodAdapter.setAll(state.codemod, action.payload);
 		},
 		upsertPrivateCodemods(
 			state,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { CodemodDescriptionProvider } from './components/webview/CodemodDescript
 import { selectExplorerTree } from './selectors/selectExplorerTree';
 import { CodemodNodeHashDigest } from './selectors/selectCodemodTree';
 import { doesJobAddNewFile } from './selectors/comparePersistedJobs';
-import { buildHash } from './utilities';
+import { buildHash, isNeitherNullNorUndefined } from './utilities';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -512,7 +512,11 @@ export async function activate(context: vscode.ExtensionContext) {
 						return;
 					}
 
-					const codemodList = await engineService.getCodemodList();
+					// TODO this should come from the store!
+
+					const codemodList = Object.values(
+						store.getState().codemod.entities,
+					).filter(isNeitherNullNorUndefined);
 
 					// order: least recent to most recent
 					const top5RecentCodemodHashes =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,11 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 
 	const codemodDescriptionProvider = new CodemodDescriptionProvider(
-		downloadService,
 		vscode.workspace.fs,
-		context.globalStorageUri,
-		messageBus,
-		store,
 	);
 
 	new IntuitaPanelProvider(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -512,8 +512,6 @@ export async function activate(context: vscode.ExtensionContext) {
 						return;
 					}
 
-					// TODO this should come from the store!
-
 					const codemodList = Object.values(
 						store.getState().codemod.entities,
 					).filter(isNeitherNullNorUndefined);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -444,12 +444,7 @@ export async function activate(context: vscode.ExtensionContext) {
 									name: codemod.name,
 							  }
 							: {
-									kind:
-										codemodHash ===
-										// app directory boilerplate
-										'QKEdp-pofR9UnglrKAGDm1Oj6W0'
-											? 'executeRepomod'
-											: 'executeCodemod',
+									kind: 'executeCodemod',
 									codemodHash,
 									name: codemod.name,
 							  };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ import { buildHash, isNeitherNullNorUndefined } from './utilities';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { homedir } from 'os';
 import { join } from 'path';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { existsSync, rmSync } from 'fs';
 
 const messageBus = new MessageBus();
@@ -436,9 +436,14 @@ export async function activate(context: vscode.ExtensionContext) {
 						codemod.kind === 'piranhaRule'
 							? {
 									kind: 'executePiranhaRule',
-									configurationUri: vscode.Uri.joinPath(
-										context.globalStorageUri,
-										codemod.configurationDirectoryBasename,
+									configurationUri: vscode.Uri.file(
+										join(
+											homedir(),
+											'.intuita',
+											createHash('ripemd160')
+												.update(codemod.name)
+												.digest('base64url'),
+										),
 									),
 									language: codemod.language,
 									name: codemod.name,
@@ -593,9 +598,14 @@ export async function activate(context: vscode.ExtensionContext) {
 						codemodEntry.kind === 'piranhaRule'
 							? {
 									kind: 'executePiranhaRule',
-									configurationUri: vscode.Uri.joinPath(
-										context.globalStorageUri,
-										codemodEntry.configurationDirectoryBasename,
+									configurationUri: vscode.Uri.file(
+										join(
+											homedir(),
+											'.intuita',
+											createHash('ripemd160')
+												.update(codemodEntry.name)
+												.digest('base64url'),
+										),
 									),
 									language: codemodEntry.language,
 									name: codemodEntry.name,


### PR DESCRIPTION
Changes:
* since now, the new version of the Codemod Engine Node will fetch the codemods into the `os.homedir()/.intuita` directory
* the arguments build by `buildArguments` function are more human readable
* the messages coming from the CEN are more readable as well, there's a new codec / schema for that
* there is no `executeRepomod` subcommand, the CEN doesn't differentiate
* the hardcoded codemod hashes are no longer in the codebase
* the `CodemodDescriptionProvider` only calculates where the descriptions are, without fetching codemods
* the action for previously upserting codemods now sets them (removing all previous codemods in the list)