### PR TITLE
INT-1791 INT-1732 handle name for private codemod

### DIFF
--- a/intuita-webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
+++ b/intuita-webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
@@ -61,6 +61,7 @@ const renderActionButtons = (
 	codemodInProgress: boolean,
 	queued: boolean,
 	rootPath: string | null,
+	label: string,
 ) => {
 	if (!codemodInProgress && !queued) {
 		const handleDryRunClick = (e: React.MouseEvent) => {
@@ -79,6 +80,7 @@ const renderActionButtons = (
 					? 'webview.codemodList.dryRunPrivateCodemod'
 					: 'webview.codemodList.dryRunCodemod',
 				value: hashDigest as unknown as CodemodHash,
+				name: label,
 			});
 		};
 		const handleCodemodLinkCopy = (e: React.MouseEvent) => {
@@ -366,6 +368,7 @@ const Codemod = ({
 								progress !== null,
 								queued,
 								rootPath,
+								label,
 							)}
 					</div>
 				</span>

--- a/src/components/webview/MainProvider.ts
+++ b/src/components/webview/MainProvider.ts
@@ -300,6 +300,7 @@ export class MainViewProvider implements WebviewViewProvider {
 				'intuita.executePrivateCodemod',
 				uri,
 				hashDigest,
+				message.name,
 			);
 		}
 

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -22,6 +22,7 @@ export type RunCodemodsCommand = Readonly<{
 		| 'webview.codemodList.dryRunCodemod'
 		| 'webview.codemodList.dryRunPrivateCodemod';
 	value: CodemodHash;
+	name: string;
 }>;
 
 export type WebviewMessage =

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -652,7 +652,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand(
 			'intuita.executePrivateCodemod',
-			async (targetUri: vscode.Uri, codemodHash: CodemodHash) => {
+			async (
+				targetUri: vscode.Uri,
+				codemodHash: CodemodHash,
+				codemodName: string,
+			) => {
 				try {
 					const { storageUri } = context;
 
@@ -682,7 +686,7 @@ export async function activate(context: vscode.ExtensionContext) {
 						command: {
 							kind: 'executeLocalCodemod',
 							codemodUri,
-							name: codemodHash,
+							name: codemodName,
 							codemodHash,
 						},
 						happenedAt: String(Date.now()),

--- a/src/telemetry/vscodeTelemetry.ts
+++ b/src/telemetry/vscodeTelemetry.ts
@@ -80,6 +80,7 @@ export class VscodeTelemetry implements Telemetry {
 	__onCodemodSetExecuted(
 		message: Message & { kind: MessageKind.codemodSetExecuted },
 	): void {
+		console.log(message);
 		this.sendEvent({
 			kind: message.halted ? 'codemodHalted' : 'codemodExecuted',
 			executionId: message.case.hash,

--- a/src/telemetry/vscodeTelemetry.ts
+++ b/src/telemetry/vscodeTelemetry.ts
@@ -80,7 +80,6 @@ export class VscodeTelemetry implements Telemetry {
 	__onCodemodSetExecuted(
 		message: Message & { kind: MessageKind.codemodSetExecuted },
 	): void {
-		console.log(message);
 		this.sendEvent({
 			kind: message.halted ? 'codemodHalted' : 'codemodExecuted',
 			executionId: message.case.hash,


### PR DESCRIPTION
1. Display private codemod name, not hash in "Results" list
2. Private codemod name should be used for report issue title

<img width="405" alt="Screenshot 2023-09-04 at 12 08 48" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/8cda73da-3810-49e3-aa8c-b4f5c4073845">
<img width="732" alt="Screenshot 2023-09-04 at 12 09 05" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/dad84fcc-8ad7-4c24-be7b-4aab9abbc334">
