### PR TITLE
INT-1409 round 1 of Ability to bring FPs from VSCE back to CS

### DIFF
--- a/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/Container.tsx
@@ -17,6 +17,7 @@ type HeaderProps = Readonly<{
 	jobHash: (PanelViewProps & { kind: 'JOB' })['jobHash'];
 	reviewed: (PanelViewProps & { kind: 'JOB' })['reviewed'];
 	onReportIssue(): void;
+	onFixInStudio(): void;
 	modifiedByUser: boolean;
 	children?: React.ReactNode;
 }>;
@@ -32,6 +33,7 @@ export const Header = ({
 	children,
 	reviewed,
 	onReportIssue,
+	onFixInStudio,
 }: HeaderProps) => {
 	const jobKindText = getJobKindText(jobKind as unknown as JobKind);
 	const hasDiff = diff !== null;
@@ -165,10 +167,17 @@ export const Header = ({
 						<VSCodeButton
 							appearance="secondary"
 							onClick={onReportIssue}
+							className="mr-1"
 						>
 							Report Issue
 						</VSCodeButton>
 					</IntuitaPopover>
+					<VSCodeButton
+						appearance="secondary"
+						onClick={onFixInStudio}
+					>
+						Fix in Studio
+					</VSCodeButton>
 				</div>
 			</div>
 			{children}

--- a/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
+++ b/intuita-webview/src/jobDiffView/DiffViewer/DiffItem.tsx
@@ -1,7 +1,7 @@
 import { Header } from './Container';
 import { Collapsable } from '../Components/Collapsable';
 import { Diff, DiffComponent } from './Diff';
-import { reportIssue } from '../util';
+import { reportIssue, exportToCodemodStudio } from '../util';
 import { KeyboardEvent, forwardRef, memo, useCallback, useState } from 'react';
 import './DiffItem.css';
 import { vscode } from '../../shared/utilities/vscode';
@@ -35,6 +35,14 @@ export const JobDiffView = memo(
 
 			const report = useCallback(() => {
 				reportIssue(
+					jobHash,
+					oldFileContent ?? '',
+					newFileContent ?? '',
+				);
+			}, [jobHash, oldFileContent, newFileContent]);
+
+			const exportToCS = useCallback(() => {
+				exportToCodemodStudio(
 					jobHash,
 					oldFileContent ?? '',
 					newFileContent ?? '',
@@ -88,6 +96,7 @@ export const JobDiffView = memo(
 								title={title ?? ''}
 								reviewed={reviewed}
 								onReportIssue={report}
+								onFixInStudio={exportToCS}
 							/>
 						}
 					>

--- a/intuita-webview/src/jobDiffView/util.ts
+++ b/intuita-webview/src/jobDiffView/util.ts
@@ -13,3 +13,16 @@ export const reportIssue = (
 		newFileContent,
 	});
 };
+
+export const exportToCodemodStudio = (
+	faultyJobHash: JobHash,
+	oldFileContent: string,
+	newFileContent: string,
+) => {
+	vscode.postMessage({
+		kind: 'webview.global.exportToCodemodStudio',
+		faultyJobHash,
+		oldFileContent,
+		newFileContent,
+	});
+};

--- a/package.json
+++ b/package.json
@@ -264,7 +264,8 @@
 		"prettier": "^2.8.8",
 		"redux-persist": "^6.0.0",
 		"semver": "^7.3.8",
-		"ts-morph": "^19.0.0"
+		"ts-morph": "^19.0.0",
+		"universal-base64url": "^1.1.0"
 	},
 	"extensionDependencies": [
 		"vscode.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ dependencies:
   ts-morph:
     specifier: ^19.0.0
     version: 19.0.0
+  universal-base64url:
+    specifier: ^1.1.0
+    version: 1.1.0
 
 devDependencies:
   '@types/chai':
@@ -3629,6 +3632,16 @@ packages:
     dependencies:
       crypto-random-string: 2.0.0
     dev: true
+
+  /universal-base64@2.1.0:
+    resolution: {integrity: sha512-WeOkACVnIXJZr/qlv7++Rl1zuZOHN96v2yS5oleUuv8eJOs5j9M5U3xQEIoWqn1OzIuIcgw0fswxWnUVGDfW6g==}
+    dev: false
+
+  /universal-base64url@1.1.0:
+    resolution: {integrity: sha512-qWv2+8KCaAWdpqqXwU8W0Yj9pflYDXP37/a3kec6Y4Je7bYzgIfxEVRjZWeLR67be7iot1lGCy5Nuo+xB0fojA==}
+    dependencies:
+      universal-base64: 2.1.0
+    dev: false
 
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}

--- a/src/components/webview/webviewEvents.ts
+++ b/src/components/webview/webviewEvents.ts
@@ -88,6 +88,12 @@ export type WebviewResponse =
 			oldFileContent: string;
 			newFileContent: string;
 	  }>
+	| Readonly<{
+			kind: 'webview.global.exportToCodemodStudio';
+			faultyJobHash: JobHash;
+			oldFileContent: string;
+			newFileContent: string;
+	  }>
 	| Omit<RunCodemodsCommand, 'title' | 'description'>
 	| Readonly<{
 			kind: 'webview.global.applySelected';


### PR DESCRIPTION
- [x] adding a "fix in studio" button that sits next to "report issue"
- [x] on click, user gets navigated to Codemod Studio with before/after snippets populated with top-level nodes caught from the file, in which the user pressed the "fix in studio" button.
- [ ] we also want to populate the codemod panel in Codemod Studio