### PR TITLE
INT-1752 Tiptap editor improvements

### DIFF
--- a/intuita-webview/src/sourceControl/CreateIssue/index.tsx
+++ b/intuita-webview/src/sourceControl/CreateIssue/index.tsx
@@ -2,7 +2,6 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import {
 	VSCodeButton,
-	VSCodeTextArea,
 	VSCodeTextField,
 } from '@vscode/webview-ui-toolkit/react';
 import { useEffect, useState } from 'react';
@@ -53,7 +52,7 @@ const CreateIssue = ({ title, body }: Props) => {
 
 	const extensions = [StarterKit];
 
-	const content = '<p>Hello World!</p>';
+	const content = formData.body;
 
 	const editor = useEditor({
 		extensions,
@@ -65,6 +64,7 @@ const CreateIssue = ({ title, body }: Props) => {
 				body: editor.getText(),
 			}));
 		},
+		autofocus: 'end',
 	});
 
 	return (

--- a/intuita-webview/src/sourceControl/CreateIssue/tiptap.css
+++ b/intuita-webview/src/sourceControl/CreateIssue/tiptap.css
@@ -2,6 +2,7 @@
 	background: var(--input-background);
 	outline: none;
 	height: 70vh;
+	overflow: auto;
 	padding: 1px calc(var(--design-unit) * 2px + 1px);
 }
 

--- a/src/components/webview/SourceControlPanelProvider.ts
+++ b/src/components/webview/SourceControlPanelProvider.ts
@@ -7,42 +7,29 @@ import { MainViewProvider } from './MainProvider';
 import { MessageBus, MessageKind } from '../messageBus';
 import { SourceControlViewProps } from './sourceControlViewProps';
 import { createBeforeAfterSnippets } from './IntuitaPanelProvider';
-import { removeLineBreaksAtStartAndEnd } from '../../utilities';
 import { actions } from '../../data/slice';
 
-const buildIssueTemplate = (
+const buildIssueTemplateInHTML = (
 	codemodName: string,
 	before: string | null,
 	after: string | null,
 	expected: string | null,
 ): string => {
 	return `
----
-:warning::warning: Please do not include any proprietary code in the issue. :warning::warning:
-
----
-Codemod: ${codemodName}
-
-**1. Code before transformation (Input for codemod)**
-
-\`\`\`jsx
-${before ?? '// paste code here'}
-\`\`\`
-
-**2. Expected code after transformation (Desired output of codemod)**
-
-\`\`\`jsx
-${expected ?? '// paste code here'}
-\`\`\`
-
-**3. Faulty code obtained after running the current version of the codemod (Actual output of codemod)**
-
-\`\`\`jsx
-${after ?? '// paste code here'}
-\`\`\`
-
----	
-**Additional context**`;
+		<hr>
+		<p>
+		<span style="font-size: 18px; font-weight: bold; color: #FFA500;">⚠️⚠️ Please do not include any proprietary code in the issue. ⚠️⚠️</span>
+		</p>
+		<hr>
+		<h3>Codemod: ${codemodName}</h3>
+		<p><strong>1. Code before transformation (Input for codemod)</strong></p>
+		<pre><code>${before ?? '// paste code here'}</code></pre>
+		<p><strong>2. Expected code after transformation (Desired output of codemod)</strong></p>
+		<pre><code>${expected ?? '// paste code here'}</code></pre>
+		<p><strong>3. Faulty code obtained after running the current version of the codemod (Actual output of codemod)</strong></p>
+		<pre><code>${after ?? '// paste code here'}</code></pre>
+		<h3>Additional context</h3>
+	`;
 };
 
 const selectSourceControlViewProps = (
@@ -72,8 +59,11 @@ const selectSourceControlViewProps = (
 		state.sourceControl.newFileContent,
 	);
 
-	const body = removeLineBreaksAtStartAndEnd(
-		buildIssueTemplate(job.codemodName, beforeSnippet, afterSnippet, null),
+	const body = buildIssueTemplateInHTML(
+		job.codemodName,
+		beforeSnippet,
+		afterSnippet,
+		null,
 	);
 
 	const title = `[Codemod:${job.codemodName}] Invalid codemod output`;


### PR DESCRIPTION
- turn our template from string to HTML because tiptap editor's `content` prop must be in HTML
- make sure editor is scrollable

<img width="653" alt="Screenshot 2023-09-07 at 05 18 19" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/f6b31ebe-4fa0-4cd4-8759-a39214f3718d">
