### PR TITLE
INT-1752 Integration 2

### DIFF
--- a/src/components/webview/SourceControlPanelProvider.ts
+++ b/src/components/webview/SourceControlPanelProvider.ts
@@ -186,7 +186,7 @@ export class SourceControlPanelProvider {
 
 						if (storedClerkToken === null) {
 							const result = await window.showInformationMessage(
-								'No Github account is linked to Intuita VSCode Extension. You need to sign in with Github to proceed.',
+								'To report issues, sign in to Intuita.',
 								{ modal: true },
 								'Sign in with Github',
 							);

--- a/src/components/webview/SourceControlPanelProvider.ts
+++ b/src/components/webview/SourceControlPanelProvider.ts
@@ -185,6 +185,16 @@ export class SourceControlPanelProvider {
 							this.__userService.getLinkedToken();
 
 						if (storedClerkToken === null) {
+							const result = await window.showInformationMessage(
+								'No Github account is linked to Intuita VSCode Extension. You need to sign in with Github to proceed.',
+								{ modal: true },
+								'Sign in with Github',
+							);
+
+							if (result !== 'Sign in with Github') {
+								return;
+							}
+
 							const searchParams = new URLSearchParams();
 
 							searchParams.set(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1028,7 +1028,7 @@ export async function activate(context: vscode.ExtensionContext) {
 						if (e instanceof AlreadyLinkedError) {
 							const result =
 								await vscode.window.showInformationMessage(
-									'It seems like your extension is already linked to another Intuita account. Would you like to link your new Intuita account instead?',
+									'A different Intuita account is already linked to Intuita VSCode Extension. Would you like to link your new Intuita account?',
 									{ modal: true },
 									'Link account',
 								);


### PR DESCRIPTION
<img width="1057" alt="Screenshot 2023-09-07 at 05 29 19" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/58527cbb-f857-4a18-a262-ff4247e12271">

- With a modal, notify the user that a linked Github account is required and hence we are routing the user to Github sign-in to proceed with creating an issue