### PR TITLE
INT-1831 two improvements to the UX/UI of reporting issue feature

### DIFF
--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -14,7 +14,7 @@ type Props = Readonly<{
 	body: string;
 }>;
 
-const CreateIssue = ({ title: titleProp, body }: Props) => {
+const CreateIssue = (props: Props) => {
 	// TODO: handle loading for creating issue
 	const [loading] = useState(false);
 
@@ -45,20 +45,20 @@ const CreateIssue = ({ title: titleProp, body }: Props) => {
 
 	const editor = useEditor({
 		extensions,
-		content: body,
+		content: props.body,
 		editable: true,
 	});
 
 	useEffect(() => {
-		setTitle(titleProp);
-	}, [titleProp]);
+		setTitle(props.title);
+	}, [props.title]);
 
 	useEffect(() => {
 		if (editor === null) {
 			return;
 		}
-		editor.commands.setContent(body, false);
-	}, [editor, body]);
+		editor.commands.setContent(props.body, false);
+	}, [editor, props.body]);
 
 	return (
 		<div className={styles.root}>

--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -21,7 +21,13 @@ const CreateIssue = (props: Props) => {
 	const [title, setTitle] = useState('');
 
 	const onChangeTitle = (e: Event | React.FormEvent<HTMLElement>) => {
-		const value = (e as React.ChangeEvent<HTMLInputElement>).target.value;
+		const value =
+			'target' in e && e.target !== null
+				? (e.target as HTMLTextAreaElement).value
+				: null;
+		if (value === null) {
+			return;
+		}
 		setTitle(value);
 	};
 

--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -22,15 +22,16 @@ const CreateIssue = (props: Props) => {
 
 	const onChangeTitle = (e: Event | React.FormEvent<HTMLElement>) => {
 		const value =
-			'target' in e && e.target !== null
-				? (e.target as HTMLTextAreaElement).value
+			'target' in e && e.target !== null && 'value' in e.target
+				? String(e.target.value)
 				: null;
+
 		if (value === null) {
 			return;
 		}
+
 		setTitle(value);
 	};
-
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 
@@ -86,7 +87,7 @@ const CreateIssue = (props: Props) => {
 						disabled={
 							loading ||
 							title.length <= 3 ||
-							(editor?.getText() || '').length <= 5
+							(editor?.getText() ?? '').length <= 5
 						}
 						type="submit"
 						className={styles.actionButton}

--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -18,7 +18,7 @@ const CreateIssue = ({ title: titleProp, body }: Props) => {
 	// TODO: handle loading for creating issue
 	const [loading] = useState(false);
 
-	const [title, setTitle] = useState(titleProp);
+	const [title, setTitle] = useState('');
 
 	const onChangeTitle = (e: Event | React.FormEvent<HTMLElement>) => {
 		const value = (e as React.ChangeEvent<HTMLInputElement>).target.value;
@@ -50,8 +50,8 @@ const CreateIssue = ({ title: titleProp, body }: Props) => {
 	});
 
 	useEffect(() => {
-		setTitle(title);
-	}, [title]);
+		setTitle(titleProp);
+	}, [titleProp]);
 
 	useEffect(() => {
 		if (editor === null) {

--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -61,10 +61,7 @@ const CreateIssue = (props: Props) => {
 	}, [props.title]);
 
 	useEffect(() => {
-		if (editor === null) {
-			return;
-		}
-		editor.commands.setContent(props.body, false);
+		editor?.commands.setContent(props.body, false);
 	}, [editor, props.body]);
 
 	return (

--- a/intuita-webview/src/CreateIssue/index.tsx
+++ b/intuita-webview/src/CreateIssue/index.tsx
@@ -7,7 +7,6 @@ import {
 import { useEffect, useState } from 'react';
 import { vscode } from '../shared/utilities/vscode';
 import styles from './style.module.css';
-import { IssueFormData } from '../../../src/components/webview/webviewEvents';
 import './tiptap.css';
 
 type Props = Readonly<{
@@ -15,58 +14,51 @@ type Props = Readonly<{
 	body: string;
 }>;
 
-const CreateIssue = ({ title, body }: Props) => {
+const CreateIssue = ({ title: titleProp, body }: Props) => {
 	// TODO: handle loading for creating issue
 	const [loading] = useState(false);
-	const [formData, setFormData] = useState<IssueFormData>({
-		title,
-		body,
-	});
 
-	useEffect(() => {
-		setFormData((prevData) => ({
-			...prevData,
-			title,
-			body,
-		}));
-	}, [title, body]);
+	const [title, setTitle] = useState(titleProp);
 
-	const onChangeFormField =
-		(fieldName: keyof IssueFormData) =>
-		(e: Event | React.FormEvent<HTMLElement>) => {
-			const value = (e as React.ChangeEvent<HTMLInputElement>).target
-				.value;
-			setFormData((prevData) => ({
-				...prevData,
-				[fieldName]: value,
-			}));
-		};
+	const onChangeTitle = (e: Event | React.FormEvent<HTMLElement>) => {
+		const value = (e as React.ChangeEvent<HTMLInputElement>).target.value;
+		setTitle(value);
+	};
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
 
+		if (editor === null) {
+			return;
+		}
+
 		vscode.postMessage({
 			kind: 'webview.sourceControl.createIssue',
-			data: formData,
+			data: {
+				title,
+				body: editor.getHTML(),
+			},
 		});
 	};
 
 	const extensions = [StarterKit];
 
-	const content = formData.body;
-
 	const editor = useEditor({
 		extensions,
-		content,
+		content: body,
 		editable: true,
-		onUpdate: ({ editor }) => {
-			setFormData((prevData) => ({
-				...prevData,
-				body: editor.getHTML(),
-			}));
-		},
-		autofocus: 'end',
 	});
+
+	useEffect(() => {
+		setTitle(title);
+	}, [title]);
+
+	useEffect(() => {
+		if (editor === null) {
+			return;
+		}
+		editor.commands.setContent(body, false);
+	}, [editor, body]);
 
 	return (
 		<div className={styles.root}>
@@ -74,8 +66,8 @@ const CreateIssue = ({ title, body }: Props) => {
 			<form onSubmit={handleSubmit} className={styles.form}>
 				<VSCodeTextField
 					placeholder="Title"
-					value={formData.title}
-					onInput={onChangeFormField('title')}
+					value={title}
+					onInput={onChangeTitle}
 					className={styles.title}
 				>
 					Title
@@ -87,8 +79,8 @@ const CreateIssue = ({ title, body }: Props) => {
 					<VSCodeButton
 						disabled={
 							loading ||
-							formData.title.length <= 3 ||
-							formData.body.length <= 5
+							title.length <= 3 ||
+							(editor?.getText() || '').length <= 5
 						}
 						type="submit"
 						className={styles.actionButton}

--- a/src/components/webview/MainProvider.ts
+++ b/src/components/webview/MainProvider.ts
@@ -63,13 +63,14 @@ export const createIssue = async (
 		return { status: 406, html_url: null };
 	}
 
+	onSuccess();
+
 	const decision = await window.showInformationMessage(
 		'Github issue is successfully created.',
-		'See the issue',
+		'See issue in Github',
 	);
-	onSuccess();
 	const { html_url } = validation.right;
-	if (decision === 'See the issue') {
+	if (decision === 'See issue in Github') {
 		commands.executeCommand('intuita.redirect', html_url);
 	}
 	return {


### PR DESCRIPTION
- [x] Textboxes for git issue creation in extension don’t clear after issue is created
- [x] pressing “report issue” must populate text boxes of git issue creation tab; often it doesn’t; (the reason must be investigated)

claap: https://app.claap.io/intuita/two-improvements-to-the-ux-ui-of-reporting-issue-feature-c-BT2DRbCjzO-pwv6SM74ESqr