### PR TITLE
INT-1902 Handle account session expiry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "intuita-vscode-extension",
 	"displayName": "Intuita",
 	"description": " Discover, run & manage codemods faster & easier.",
-	"version": "0.36.13",
+	"version": "0.36.14",
 	"publisher": "Intuita",
 	"icon": "img/intuita_square128.png",
 	"repository": {


### PR DESCRIPTION
- If access token stored in vscode extension storage is invalid, automatically sign out user and show notif saying "'You are signed out because your session has expired.'". 

- icon on the sidebar toolbar must change to reflect the account sign-in status