### PR TITLE
INT-2094 Can't understand that `*` means a required codemod arg

### DIFF
--- a/intuita-webview/src/codemodList/CodemodArguments/FormField/index.tsx
+++ b/intuita-webview/src/codemodList/CodemodArguments/FormField/index.tsx
@@ -22,7 +22,7 @@ const FormField = (props: Props) => {
 				className={styles.field}
 				title={description}
 			>
-				{name} {required && '*'}
+				{name} {required && '(required)'}
 			</VSCodeTextField>
 		);
 	}


### PR DESCRIPTION
Result

<img width="787" alt="Screenshot 2024-01-03 at 11 17 54" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/497e2145-f0e7-447c-9767-a2bb86c1ffa9">
